### PR TITLE
Add rule for detecting nodes with no references

### DIFF
--- a/packages/search/src/problems.worker.ts
+++ b/packages/search/src/problems.worker.ts
@@ -39,6 +39,7 @@ import { unknownRepeatIndexFormulaRule } from './rules/formulas/unknownRepeatInd
 import { unknownRepeatItemFormulaRule } from './rules/formulas/unknownRepeatItemFormulaRule'
 import { noUnnecessaryConditionFalsy } from './rules/logic/noUnnecessaryConditionFalsy'
 import { noUnnecessaryConditionTruthy } from './rules/logic/noUnnecessaryConditionTruthy'
+import { noReferenceNodeRule } from './rules/noReferenceNodeRule'
 import { requireExtensionRule } from './rules/requireExtensionRule'
 import { unknownClassnameRule } from './rules/slots/unknownClassnameRule'
 import { unknownComponentSlotRule } from './rules/slots/unknownComponentSlotRule'
@@ -156,6 +157,7 @@ const RULES = [
   noReferenceComponentRule,
   noReferenceComponentWorkflowRule,
   noReferenceEventRule,
+  noReferenceNodeRule,
   noReferenceProjectActionRule,
   noReferenceProjectFormulaRule,
   noReferenceVariableRule,

--- a/packages/search/src/rules/noReferenceNodeRule.test.ts
+++ b/packages/search/src/rules/noReferenceNodeRule.test.ts
@@ -1,0 +1,84 @@
+import { searchProject } from '../searchProject'
+import { noReferenceNodeRule } from './noReferenceNodeRule'
+
+describe('noReferenceNodeRule', () => {
+  test('should detect nodes with no references', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          formulas: {},
+          components: {
+            test: {
+              name: 'test',
+              nodes: {
+                root: {
+                  id: 'root',
+                  type: 'element',
+                  tag: 'div',
+                  children: [],
+                  attrs: {},
+                  style: {},
+                  events: {},
+                  classes: {},
+                },
+                '1LisbD0eCjsuccoUwajn1': {
+                  id: 'XdhwPGsdFNI4s8A0oMwre',
+                  type: 'text',
+                  value: { type: 'value', value: 'Clone the project' },
+                },
+              },
+              formulas: {},
+              apis: {},
+              attributes: {},
+              variables: {},
+            },
+          },
+        },
+        rules: [noReferenceNodeRule],
+      }),
+    )
+
+    expect(problems).toHaveLength(1)
+    expect(problems[0].details).toEqual({ node: '1LisbD0eCjsuccoUwajn1' })
+    expect(problems[0].path).toEqual(['components', 'test'])
+  })
+
+  test('should not detect nodes with references', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          formulas: {},
+          components: {
+            test: {
+              name: 'test',
+              nodes: {
+                root: {
+                  id: 'root',
+                  type: 'element',
+                  tag: 'div',
+                  children: ['1LisbD0eCjsuccoUwajn1'],
+                  attrs: {},
+                  style: {},
+                  events: {},
+                  classes: {},
+                },
+                '1LisbD0eCjsuccoUwajn1': {
+                  id: 'XdhwPGsdFNI4s8A0oMwre',
+                  type: 'text',
+                  value: { type: 'value', value: 'Clone the project' },
+                },
+              },
+              formulas: {},
+              apis: {},
+              attributes: {},
+              variables: {},
+            },
+          },
+        },
+        rules: [noReferenceNodeRule],
+      }),
+    )
+
+    expect(problems).toEqual([])
+  })
+})

--- a/packages/search/src/rules/noReferenceNodeRule.test.ts
+++ b/packages/search/src/rules/noReferenceNodeRule.test.ts
@@ -92,7 +92,7 @@ describe('find noReferenceNodeRule', () => {
 })
 
 describe('fix noReferenceNodeRule', () => {
-  test.only('should delete nodes with no references', () => {
+  test('should delete nodes with no references', () => {
     const files: ProjectFiles = {
       formulas: {},
       components: {

--- a/packages/search/src/rules/noReferenceNodeRule.test.ts
+++ b/packages/search/src/rules/noReferenceNodeRule.test.ts
@@ -1,8 +1,10 @@
+import type { ProjectFiles } from '@nordcraft/ssr/dist/ssr.types'
 import { describe, expect, test } from 'bun:test'
+import { fixProject } from '../fixProject'
 import { searchProject } from '../searchProject'
 import { noReferenceNodeRule } from './noReferenceNodeRule'
 
-describe('noReferenceNodeRule', () => {
+describe('find noReferenceNodeRule', () => {
   test('should detect nodes with no references', () => {
     const problems = Array.from(
       searchProject({
@@ -41,7 +43,12 @@ describe('noReferenceNodeRule', () => {
 
     expect(problems).toHaveLength(1)
     expect(problems[0].details).toEqual({ node: '1LisbD0eCjsuccoUwajn1' })
-    expect(problems[0].path).toEqual(['components', 'test'])
+    expect(problems[0].path).toEqual([
+      'components',
+      'test',
+      'nodes',
+      '1LisbD0eCjsuccoUwajn1',
+    ])
   })
 
   test('should not detect nodes with references', () => {
@@ -81,5 +88,53 @@ describe('noReferenceNodeRule', () => {
     )
 
     expect(problems).toEqual([])
+  })
+})
+
+describe('fix noReferenceNodeRule', () => {
+  test.only('should delete nodes with no references', () => {
+    const files: ProjectFiles = {
+      formulas: {},
+      components: {
+        test: {
+          name: 'test',
+          nodes: {
+            root: {
+              id: 'root',
+              type: 'element',
+              tag: 'div',
+              children: ['used'],
+              attrs: {},
+              style: {},
+              events: {},
+              classes: {},
+            },
+            '1LisbD0eCjsuccoUwajn1': {
+              id: 'XdhwPGsdFNI4s8A0oMwre',
+              type: 'text',
+              value: { type: 'value', value: 'Clone the project' },
+            },
+            used: {
+              id: 'used',
+              type: 'text',
+              value: { type: 'value', value: 'I am used' },
+            },
+          },
+          formulas: {},
+          apis: {},
+          attributes: {},
+          variables: {},
+        },
+      },
+    }
+    const fixedFiles = fixProject({
+      files,
+      rule: noReferenceNodeRule,
+      fixType: 'delete orphan node',
+    })
+    expect(Object.keys(fixedFiles.components.test!.nodes)).toEqual([
+      'root',
+      'used',
+    ])
   })
 })

--- a/packages/search/src/rules/noReferenceNodeRule.test.ts
+++ b/packages/search/src/rules/noReferenceNodeRule.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from 'bun:test'
 import { searchProject } from '../searchProject'
 import { noReferenceNodeRule } from './noReferenceNodeRule'
 

--- a/packages/search/src/rules/noReferenceNodeRule.ts
+++ b/packages/search/src/rules/noReferenceNodeRule.ts
@@ -1,0 +1,23 @@
+import type { Rule } from '../types'
+
+export const noReferenceNodeRule: Rule<{ node: string }> = {
+  code: 'no-reference node',
+  level: 'warning',
+  category: 'No References',
+  visit: (report, args) => {
+    if (args.nodeType !== 'component') {
+      return
+    }
+    const { path, value: component } = args
+    const referencedNodes = new Set(
+      Object.values(component.nodes).flatMap((node) => node.children ?? []),
+    )
+    // We'll report the first unused node we find
+    for (const key of Object.keys(component.nodes)) {
+      if (key !== 'root' && !referencedNodes.has(key)) {
+        report(path, { node: key })
+        return
+      }
+    }
+  },
+}

--- a/packages/search/src/rules/noReferenceNodeRule.ts
+++ b/packages/search/src/rules/noReferenceNodeRule.ts
@@ -1,4 +1,5 @@
 import type { Rule } from '../types'
+import { removeFromPathFix } from '../util/removeUnused.fix'
 
 export const noReferenceNodeRule: Rule<{ node: string }> = {
   code: 'no-reference node',
@@ -12,12 +13,15 @@ export const noReferenceNodeRule: Rule<{ node: string }> = {
     const referencedNodes = new Set(
       Object.values(component.nodes).flatMap((node) => node.children ?? []),
     )
-    // We'll report the first unused node we find
     for (const key of Object.keys(component.nodes)) {
       if (key !== 'root' && !referencedNodes.has(key)) {
-        report(path, { node: key })
-        return
+        report([...path, 'nodes', key], { node: key }, ['delete orphan node'])
       }
     }
   },
+  fixes: {
+    'delete orphan node': removeFromPathFix,
+  },
 }
+
+export type NoReferenceNodeRuleFix = 'delete orphan node'

--- a/packages/search/src/searchProject.ts
+++ b/packages/search/src/searchProject.ts
@@ -262,7 +262,10 @@ function* visitNode({
               // The rule must have an implementation for the fix
               rule.fixes?.[fixOptions.fixType]
             ) {
-              const ruleFixes = rule.fixes[fixOptions.fixType]?.(data, state)
+              const ruleFixes = rule.fixes[fixOptions.fixType]?.(
+                { ...data, path },
+                state,
+              )
               if (ruleFixes) {
                 fixedFiles = ruleFixes
               }

--- a/packages/search/src/types.d.ts
+++ b/packages/search/src/types.d.ts
@@ -30,6 +30,7 @@ import type { NoReferenceEventRuleFix } from './rules/events/noReferenceEventRul
 import type { LegacyFormulaRuleFix } from './rules/formulas/legacyFormulaRule'
 import type { NoReferenceComponentFormulaRuleFix } from './rules/formulas/noReferenceComponentFormulaRule'
 import type { NoReferenceProjectFormulaRuleFix } from './rules/formulas/noReferenceProjectFormulaRule'
+import { NoReferenceNodeRuleFix } from './rules/noReferenceNodeRule'
 
 type Code =
   | 'ambiguous style variable syntax'
@@ -329,8 +330,9 @@ type FixType =
   | NoReferenceAttributeRuleFix
   | NoReferenceEventRuleFix
   | NoReferenceComponentFormulaRuleFix
+  | NoReferenceNodeRuleFix
 
-export interface Rule<T = unknown, V = NodeType> {
+export interface Rule<T = unknown, V = NodeType, F = NodeType> {
   category: Category
   code: Code
   level: Level
@@ -339,7 +341,7 @@ export interface Rule<T = unknown, V = NodeType> {
     data: V,
     state?: ApplicationState | undefined,
   ) => void
-  fixes?: Partial<Record<FixType, FixFunction>>
+  fixes?: Partial<Record<FixType, FixFunction<F>>>
 }
 
 export type FixFunction<T extends NodeType> = (

--- a/packages/search/src/types.d.ts
+++ b/packages/search/src/types.d.ts
@@ -14,9 +14,9 @@ import type { ToddleComponent } from '@nordcraft/core/dist/component/ToddleCompo
 import type { Formula } from '@nordcraft/core/dist/formula/formula'
 import type { PluginFormula } from '@nordcraft/core/dist/formula/formulaTypes'
 import type { Theme } from '@nordcraft/core/dist/styling/theme'
+import type { PluginAction } from '@nordcraft/core/dist/types'
 import type {
   ApiService,
-  PluginAction,
   ProjectFiles,
   Route,
   ToddleProject,
@@ -30,7 +30,7 @@ import type { NoReferenceEventRuleFix } from './rules/events/noReferenceEventRul
 import type { LegacyFormulaRuleFix } from './rules/formulas/legacyFormulaRule'
 import type { NoReferenceComponentFormulaRuleFix } from './rules/formulas/noReferenceComponentFormulaRule'
 import type { NoReferenceProjectFormulaRuleFix } from './rules/formulas/noReferenceProjectFormulaRule'
-import { NoReferenceNodeRuleFix } from './rules/noReferenceNodeRule'
+import type { NoReferenceNodeRuleFix } from './rules/noReferenceNodeRule'
 
 type Code =
   | 'ambiguous style variable syntax'

--- a/packages/search/src/types.d.ts
+++ b/packages/search/src/types.d.ts
@@ -332,7 +332,7 @@ type FixType =
   | NoReferenceComponentFormulaRuleFix
   | NoReferenceNodeRuleFix
 
-export interface Rule<T = unknown, V = NodeType, F = NodeType> {
+export interface Rule<T = unknown, V = NodeType> {
   category: Category
   code: Code
   level: Level
@@ -341,7 +341,7 @@ export interface Rule<T = unknown, V = NodeType, F = NodeType> {
     data: V,
     state?: ApplicationState | undefined,
   ) => void
-  fixes?: Partial<Record<FixType, FixFunction<F>>>
+  fixes?: Partial<Record<FixType, FixFunction>>
 }
 
 export type FixFunction<T extends NodeType> = (

--- a/packages/search/src/types.d.ts
+++ b/packages/search/src/types.d.ts
@@ -53,6 +53,7 @@ type Code =
   | 'no-reference component workflow'
   | 'no-reference component'
   | 'no-reference event'
+  | 'no-reference node'
   | 'no-reference project action'
   | 'no-reference project formula'
   | 'no-reference variable'


### PR DESCRIPTION
I plan to add a feature flag which will exclude this rule for all users except for users who opt in. Currently, it's not possible to perform any action based on this rule, but it's an obvious candidate for a rule that could be used to automatically delete nodes that are not referenced by any other nodes.

In the toddle project, this rule creates 39 issues (meaning 39 different components). If we flag each unused node (multiple times per component), this rule would create 63 issues.