### PR TITLE
Do not report formula and workflows that are exposed in context and on a package-exported component

### DIFF
--- a/packages/core/src/component/ToddleComponent.ts
+++ b/packages/core/src/component/ToddleComponent.ts
@@ -467,4 +467,8 @@ export class ToddleComponent<Handler> {
   get contexts() {
     return this.component.contexts
   }
+
+  get exported() {
+    return this.component.exported
+  }
 }

--- a/packages/search/src/rules/formulas/noReferenceComponentFormulaRule.ts
+++ b/packages/search/src/rules/formulas/noReferenceComponentFormulaRule.ts
@@ -29,6 +29,11 @@ export const noReferenceComponentFormulaRule: Rule<{
       }
     }
 
+    // Short circuit if the component is exported and the formula is exposed in context, as it is always indirectly used
+    if (value.exposeInContext && component.exported) {
+      return
+    }
+
     // It is possible that a formula is never used, but still has subscribers
     const contextSubscribers = []
     if (value.exposeInContext) {

--- a/packages/search/src/rules/workflows/noReferenceComponentWorkflowRule.ts
+++ b/packages/search/src/rules/workflows/noReferenceComponentWorkflowRule.ts
@@ -32,6 +32,11 @@ export const noReferenceComponentWorkflowRule: Rule<{
       }
     }
 
+    // Short circuit if the component is exported and the workflow is exposed in context, as it is always indirectly used
+    if (value.exposeInContext && component.exported) {
+      return
+    }
+
     // It is possible that a formula is never used, but still has subscribers
     const contextSubscribers = []
     if (value.exposeInContext) {


### PR DESCRIPTION
You can recreate this issue by creating a formula or action and set expose in context, but not consuming it anywhere in the package. If the component is then exported, it should now not report as an issue.

Package component context is a pattern we allowed recently. Components that are not exported cannot have their context subscribed, so we should handle them as before.