### PR TITLE
Add rule for detecting actions after navigate

### DIFF
--- a/packages/search/src/problems.worker.ts
+++ b/packages/search/src/problems.worker.ts
@@ -46,6 +46,7 @@ import { noReferenceVariableRule } from './rules/variables/noReferenceVariableRu
 import { unknownVariableRule } from './rules/variables/unknownVariableRule'
 import { unknownVariableSetterRule } from './rules/variables/unknownVariableSetterRule'
 import { duplicateWorkflowParameterRule } from './rules/workflows/duplicateWorkflowParameterRule'
+import { noPostNavigateAction } from './rules/workflows/noPostNavigateAction'
 import { noReferenceComponentWorkflowRule } from './rules/workflows/noReferenceComponentWorkflowRule'
 import { unknownContextProviderWorkflowRule } from './rules/workflows/unknownContextProviderWorkflowRule'
 import { unknownContextWorkflowRule } from './rules/workflows/unknownContextWorkflowRule'
@@ -125,6 +126,7 @@ const RULES = [
   legacyFormulaRule,
   noContextConsumersRule,
   nonEmptyVoidElementRule,
+  noPostNavigateAction,
   noReferenceApiRule,
   noReferenceAttributeRule,
   noReferenceComponentFormulaRule,

--- a/packages/search/src/rules/workflows/noPostNavigateAction.test.ts
+++ b/packages/search/src/rules/workflows/noPostNavigateAction.test.ts
@@ -109,7 +109,7 @@ describe('noPostNavigateAction', () => {
       'events',
       'click',
       'actions',
-      '1',
+      '0',
     ])
   })
   test('should detect workflow actions after a url navigate action', () => {
@@ -193,7 +193,7 @@ describe('noPostNavigateAction', () => {
       'workflows',
       'RGyFQC',
       'actions',
-      '1',
+      '0',
     ])
   })
   test('should detect onLoad actions after a url navigate action', () => {
@@ -273,7 +273,7 @@ describe('noPostNavigateAction', () => {
       'nav',
       'onLoad',
       'actions',
-      '1',
+      '0',
     ])
   })
   test('should not report issues if navigate is the last action', () => {

--- a/packages/search/src/rules/workflows/noPostNavigateAction.test.ts
+++ b/packages/search/src/rules/workflows/noPostNavigateAction.test.ts
@@ -1,0 +1,458 @@
+import { searchProject } from '../../searchProject'
+import { noPostNavigateAction } from './noPostNavigateAction'
+
+describe('noPostNavigateAction', () => {
+  test('should detect actions after a url navigate action', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          formulas: {},
+          components: {
+            nav: {
+              attributes: {},
+              events: [],
+              formulas: {},
+              nodes: {
+                root: {
+                  type: 'element',
+                  tag: 'div',
+                  attrs: {},
+                  classes: {},
+                  events: {},
+                  children: ['wkPXF99C3qdRgZmUcnHO_'],
+                  style: {},
+                },
+                wkPXF99C3qdRgZmUcnHO_: {
+                  tag: 'button',
+                  type: 'element',
+                  attrs: {},
+                  style: {
+                    color: 'var(--grey-200, #E5E5E5)',
+                    'border-radius': '6px',
+                    'background-color': 'var(--blue-600, #2563EB)',
+                    'padding-left': '8px',
+                    'padding-right': '8px',
+                    'padding-top': '8px',
+                    'padding-bottom': '8px',
+                    width: 'fit-content',
+                    cursor: 'pointer',
+                  },
+                  events: {
+                    click: {
+                      trigger: 'click',
+                      actions: [
+                        {
+                          name: '@toddle/gotToURL',
+                          arguments: [
+                            {
+                              name: 'URL',
+                              formula: {
+                                type: 'value',
+                                value: 'https://example.com',
+                              },
+                            },
+                          ],
+                          label: 'Go to URL',
+                        },
+                        {
+                          name: '@toddle/logToConsole',
+                          arguments: [
+                            {
+                              name: 'Label',
+                              formula: {
+                                type: 'value',
+                                value: '',
+                              },
+                            },
+                            {
+                              name: 'Data',
+                              formula: {
+                                type: 'value',
+                                value: '<Data>',
+                              },
+                            },
+                          ],
+                          label: 'Log to console',
+                        },
+                      ],
+                    },
+                  },
+                  classes: {},
+                  children: ['zFhmZR6YnLy089HmlK-Yn'],
+                  variants: [],
+                },
+                'zFhmZR6YnLy089HmlK-Yn': {
+                  type: 'text',
+                  value: {
+                    type: 'value',
+                    value: 'Button',
+                  },
+                },
+              },
+              variables: {},
+              apis: {},
+              name: 'nav',
+            },
+          },
+        },
+        rules: [noPostNavigateAction],
+      }),
+    )
+
+    expect(problems).toHaveLength(1)
+    expect(problems[0].code).toBe('no post navigate action')
+    expect(problems[0].path).toEqual([
+      'components',
+      'nav',
+      'nodes',
+      'wkPXF99C3qdRgZmUcnHO_',
+      'events',
+      'click',
+      'actions',
+      '1',
+    ])
+  })
+  test('should detect workflow actions after a url navigate action', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          formulas: {},
+          components: {
+            nav: {
+              attributes: {},
+              events: [],
+              formulas: {},
+              nodes: {
+                root: {
+                  type: 'element',
+                  tag: 'div',
+                  attrs: {},
+                  classes: {},
+                  events: {},
+                  children: [],
+                  style: {},
+                },
+              },
+              variables: {},
+              apis: {},
+              name: 'nav2',
+              workflows: {
+                RGyFQC: {
+                  parameters: [],
+                  name: 'Navigate',
+                  actions: [
+                    {
+                      name: '@toddle/gotToURL',
+                      arguments: [
+                        {
+                          name: 'URL',
+                          formula: {
+                            type: 'value',
+                            value: 'https://example.com',
+                          },
+                        },
+                      ],
+                      label: 'Go to URL',
+                    },
+                    {
+                      name: '@toddle/logToConsole',
+                      arguments: [
+                        {
+                          name: 'Label',
+                          formula: {
+                            type: 'value',
+                            value: 'test',
+                          },
+                        },
+                        {
+                          name: 'Data',
+                          formula: {
+                            type: 'value',
+                            value: '<Data>',
+                          },
+                        },
+                      ],
+                      label: 'Log to console',
+                    },
+                  ],
+                  exposeInContext: false,
+                },
+              },
+            },
+          },
+        },
+        rules: [noPostNavigateAction],
+      }),
+    )
+
+    expect(problems).toHaveLength(1)
+    expect(problems[0].code).toBe('no post navigate action')
+    expect(problems[0].path).toEqual([
+      'components',
+      'nav',
+      'workflows',
+      'RGyFQC',
+      'actions',
+      '1',
+    ])
+  })
+  test('should detect onLoad actions after a url navigate action', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          formulas: {},
+          components: {
+            nav: {
+              attributes: {},
+              onLoad: {
+                trigger: 'Load',
+                actions: [
+                  {
+                    name: '@toddle/gotToURL',
+                    arguments: [
+                      {
+                        name: 'URL',
+                        formula: {
+                          type: 'value',
+                          value: 'https://example.com',
+                        },
+                      },
+                    ],
+                    label: 'Go to URL',
+                  },
+                  {
+                    name: '@toddle/logToConsole',
+                    arguments: [
+                      {
+                        name: 'Label',
+                        formula: {
+                          type: 'value',
+                          value: '',
+                        },
+                      },
+                      {
+                        name: 'Data',
+                        formula: {
+                          type: 'value',
+                          value: '<Data>',
+                        },
+                      },
+                    ],
+                    label: 'Log to console',
+                  },
+                ],
+              },
+              events: [],
+              formulas: {},
+              nodes: {
+                root: {
+                  type: 'element',
+                  tag: 'div',
+                  attrs: {},
+                  classes: {},
+                  events: {},
+                  children: [],
+                  style: {},
+                },
+              },
+              variables: {},
+              apis: {},
+              name: 'nav2',
+              workflows: {},
+            },
+          },
+        },
+        rules: [noPostNavigateAction],
+      }),
+    )
+
+    expect(problems).toHaveLength(1)
+    expect(problems[0].code).toBe('no post navigate action')
+    expect(problems[0].path).toEqual([
+      'components',
+      'nav',
+      'onLoad',
+      'actions',
+      '1',
+    ])
+  })
+  test('should not report issues if navigate is the last action', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          formulas: {},
+          components: {
+            nav: {
+              attributes: {},
+              events: [],
+              formulas: {},
+              workflows: {
+                RGyFQC: {
+                  parameters: [],
+                  name: 'Navigate',
+                  actions: [
+                    {
+                      name: '@toddle/logToConsole',
+                      arguments: [
+                        {
+                          name: 'Label',
+                          formula: {
+                            type: 'value',
+                            value: 'test',
+                          },
+                        },
+                        {
+                          name: 'Data',
+                          formula: {
+                            type: 'value',
+                            value: '<Data>',
+                          },
+                        },
+                      ],
+                      label: 'Log to console',
+                    },
+                    {
+                      name: '@toddle/gotToURL',
+                      arguments: [
+                        {
+                          name: 'URL',
+                          formula: {
+                            type: 'value',
+                            value: 'https://example.com',
+                          },
+                        },
+                      ],
+                      label: 'Go to URL',
+                    },
+                  ],
+                  exposeInContext: false,
+                },
+              },
+              onLoad: {
+                trigger: 'Load',
+                actions: [
+                  {
+                    name: '@toddle/logToConsole',
+                    arguments: [
+                      {
+                        name: 'Label',
+                        formula: {
+                          type: 'value',
+                          value: '',
+                        },
+                      },
+                      {
+                        name: 'Data',
+                        formula: {
+                          type: 'value',
+                          value: '<Data>',
+                        },
+                      },
+                    ],
+                    label: 'Log to console',
+                  },
+                  {
+                    name: '@toddle/gotToURL',
+                    arguments: [
+                      {
+                        name: 'URL',
+                        formula: {
+                          type: 'value',
+                          value: 'https://example.com',
+                        },
+                      },
+                    ],
+                    label: 'Go to URL',
+                  },
+                ],
+              },
+              nodes: {
+                root: {
+                  type: 'element',
+                  tag: 'div',
+                  attrs: {},
+                  classes: {},
+                  events: {},
+                  children: ['wkPXF99C3qdRgZmUcnHO_'],
+                  style: {},
+                },
+                wkPXF99C3qdRgZmUcnHO_: {
+                  tag: 'button',
+                  type: 'element',
+                  attrs: {},
+                  style: {
+                    color: 'var(--grey-200, #E5E5E5)',
+                    'border-radius': '6px',
+                    'background-color': 'var(--blue-600, #2563EB)',
+                    'padding-left': '8px',
+                    'padding-right': '8px',
+                    'padding-top': '8px',
+                    'padding-bottom': '8px',
+                    width: 'fit-content',
+                    cursor: 'pointer',
+                  },
+                  events: {
+                    click: {
+                      trigger: 'click',
+                      actions: [
+                        {
+                          name: '@toddle/logToConsole',
+                          arguments: [
+                            {
+                              name: 'Label',
+                              formula: {
+                                type: 'value',
+                                value: '',
+                              },
+                            },
+                            {
+                              name: 'Data',
+                              formula: {
+                                type: 'value',
+                                value: '<Data>',
+                              },
+                            },
+                          ],
+                          label: 'Log to console',
+                        },
+                        {
+                          name: '@toddle/gotToURL',
+                          arguments: [
+                            {
+                              name: 'URL',
+                              formula: {
+                                type: 'value',
+                                value: 'https://example.com',
+                              },
+                            },
+                          ],
+                          label: 'Go to URL',
+                        },
+                      ],
+                    },
+                  },
+                  classes: {},
+                  children: ['zFhmZR6YnLy089HmlK-Yn'],
+                  variants: [],
+                },
+                'zFhmZR6YnLy089HmlK-Yn': {
+                  type: 'text',
+                  value: {
+                    type: 'value',
+                    value: 'Button',
+                  },
+                },
+              },
+              variables: {},
+              apis: {},
+              name: 'nav',
+            },
+          },
+        },
+        rules: [noPostNavigateAction],
+      }),
+    )
+
+    expect(problems).toHaveLength(0)
+  })
+})

--- a/packages/search/src/rules/workflows/noPostNavigateAction.ts
+++ b/packages/search/src/rules/workflows/noPostNavigateAction.ts
@@ -23,8 +23,9 @@ export const noPostNavigateAction: Rule<{ parameter: string }> = {
       return
     }
     const actionIndex = Number(_actionIndex)
-    actions.slice(actionIndex + 1).forEach((_, i) => {
-      report([...actionsArrayPath, String(actionIndex + 1 + i)])
-    })
+    if (actionIndex < actions.length - 1) {
+      // If the action is not the last one in the array, report it
+      report(path)
+    }
   },
 }

--- a/packages/search/src/rules/workflows/noPostNavigateAction.ts
+++ b/packages/search/src/rules/workflows/noPostNavigateAction.ts
@@ -1,0 +1,30 @@
+import { get } from '@nordcraft/core/dist/utils/collections'
+import type { Rule } from '../../types'
+
+export const noPostNavigateAction: Rule<{ parameter: string }> = {
+  code: 'no post navigate action',
+  level: 'warning',
+  category: 'Quality',
+  visit: (report, { nodeType, path, value, files }) => {
+    if (
+      nodeType !== 'action-model' ||
+      value.type !== undefined ||
+      value.name !== '@toddle/gotToURL'
+    ) {
+      return
+    }
+    const actionsArrayPath = path.slice(0, -1).map((p) => String(p))
+    const actions = get(files, actionsArrayPath)
+    if (!Array.isArray(actions)) {
+      return
+    }
+    const _actionIndex = path.at(-1)
+    if (_actionIndex === undefined) {
+      return
+    }
+    const actionIndex = Number(_actionIndex)
+    actions.slice(actionIndex + 1).forEach((_, i) => {
+      report([...actionsArrayPath, String(actionIndex + 1 + i)])
+    })
+  },
+}

--- a/packages/search/src/types.d.ts
+++ b/packages/search/src/types.d.ts
@@ -32,6 +32,7 @@ type Code =
   | 'legacy api'
   | 'legacy formula'
   | 'no context consumers'
+  | 'no post navigate action'
   | 'no-console'
   | 'no-reference api input'
   | 'no-reference api'


### PR DESCRIPTION
Performing any action after using a "Go to URL" action is error prone and there's a chance those actions will not be executed.
This rule detects any action that is executed after a "Go to URL" action in:

- Events
- Workflows
- On load events
  
Closes https://github.com/nordcraftengine/nordcraft-internal/issues/2007