### PR TITLE
Fallback to project if package formula does not exist

### DIFF
--- a/packages/core/src/component/ToddleComponent.ts
+++ b/packages/core/src/component/ToddleComponent.ts
@@ -89,11 +89,27 @@ export class ToddleComponent<Handler> {
             packageName?: string
           } => entry.formula.type === 'function',
         )
-        .map((entry) =>
-          [entry.formula.package ?? entry.packageName, entry.formula.name]
-            .filter(isDefined)
-            .join('/'),
-        ),
+        .map((entry) => {
+          let packageName = entry.formula.package ?? entry.packageName
+          if (
+            packageName &&
+            !this.globalFormulas.packages?.[packageName].formulas?.[
+              entry.formula.name
+            ]
+          ) {
+            packageName = undefined
+          }
+
+          if (
+            !packageName &&
+            !this.globalFormulas.formulas?.[entry.formula.name]
+          ) {
+            return
+          }
+
+          return [packageName, entry.formula.name].filter(isDefined).join('/')
+        })
+        .filter(isDefined),
     )
   }
 


### PR DESCRIPTION
Fix the issue we saw at https://debug-telepathwork.toddle.site/en/jobs?country=219 with `1.0.3`.