### PR TITLE
Only add global formulas if they exist and allow multiple with the same name across packages

### DIFF
--- a/packages/core/src/component/ToddleComponent.ts
+++ b/packages/core/src/component/ToddleComponent.ts
@@ -89,18 +89,23 @@ export class ToddleComponent<Handler> {
             packageName?: string
           } => entry.formula.type === 'function',
         )
-        .map((entry) => {
-          let packageName = entry.formula.package ?? entry.packageName
+        .flatMap((entry) => {
+          const refs: string[] = []
+          const packageName = entry.formula.package ?? entry.packageName
           if (
             packageName &&
-            !this.globalFormulas.packages?.[packageName]?.formulas?.[
+            this.globalFormulas.packages?.[packageName]?.formulas?.[
               entry.formula.name
             ]
           ) {
-            packageName = undefined
+            refs.push([packageName, entry.formula.name].join('/'))
           }
 
-          return [packageName, entry.formula.name].filter(isDefined).join('/')
+          if (this.globalFormulas.formulas?.[entry.formula.name]) {
+            refs.push(entry.formula.name)
+          }
+
+          return refs
         }),
     )
   }

--- a/packages/core/src/component/ToddleComponent.ts
+++ b/packages/core/src/component/ToddleComponent.ts
@@ -90,8 +90,9 @@ export class ToddleComponent<Handler> {
           } => entry.formula.type === 'function',
         )
         .flatMap((entry) => {
-          const refs: string[] = []
-          const packageName = entry.formula.package ?? entry.packageName
+          const refs = [entry.formula.name]
+          const packageName =
+            entry.formula.package ?? entry.packageName ?? this.packageName
           if (
             packageName &&
             this.globalFormulas.packages?.[packageName]?.formulas?.[
@@ -99,10 +100,6 @@ export class ToddleComponent<Handler> {
             ]
           ) {
             refs.push([packageName, entry.formula.name].join('/'))
-          }
-
-          if (this.globalFormulas.formulas?.[entry.formula.name]) {
-            refs.push(entry.formula.name)
           }
 
           return refs


### PR DESCRIPTION
This solves an issue on the new docs where a formula `document` exists in both sparkcore and the project itself. It would only be found in the package and throw an error for the project on attempted use. It should live both places.

There is still an issue as arguments to package formulas doesn't know if they are inside the package logic or in the project. I don't believe this is a solvable problem with our current structure. Similar issues exist for action callbacks and component slots.

This solution should make this rare issue most often work. In this case the two formulas also happen to do the same.