### PR TITLE
Adjust behavior for unknown cookies in template

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nordcraft",
   "type": "module",
   "license": "Apache-2.0",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "homepage": "https://github.com/nordcraftengine/nordcraft",
   "private": "false",
   "workspaces": [

--- a/packages/backend/src/middleware/pageLoader.ts
+++ b/packages/backend/src/middleware/pageLoader.ts
@@ -25,5 +25,11 @@ export const pageLoader: MiddlewareHandler<
     ctx.set('files', pageContent)
     return next()
   }
-  return ctx.text('Page not found', { status: 404 })
+  return ctx.text('Page not found', {
+    status: 404,
+    headers: {
+      // Temporary debug header for debugging the backend's routing logic
+      X_NC_DEBUG: JSON.stringify(ctx.var.routes.pages),
+    },
+  })
 }

--- a/packages/ssr/src/rendering/template.test.ts
+++ b/packages/ssr/src/rendering/template.test.ts
@@ -15,4 +15,14 @@ describe('template', () => {
       'this is a test my-access-token and another value my-refresh-token + finally my-access-token',
     )
   })
+  test('it replaces unknown cookies with an empty string', () => {
+    expect(
+      applyTemplateValues(
+        'this is a test {{ cookies.unknown_cookie }} and {{ cookies.known_cookie }}',
+        {
+          known_cookie: 'my-known-cookie',
+        },
+      ),
+    ).toEqual('this is a test  and my-known-cookie')
+  })
 })

--- a/packages/ssr/src/rendering/template.ts
+++ b/packages/ssr/src/rendering/template.ts
@@ -5,7 +5,7 @@ import { skipCookieHeader, skipToddleHeader } from '../utils/headers'
 
 export const applyTemplateValues = (
   input: string | null | undefined,
-  cookies: ToddleServerEnv['request']['cookies'],
+  cookies: Partial<ToddleServerEnv['request']['cookies']>,
 ) => {
   if (!isDefined(input)) {
     return ''
@@ -23,12 +23,12 @@ export const applyTemplateValues = (
   }
   for (const cookieName of cookieNames) {
     const cookieValue = cookies[cookieName]
-    if (cookieValue) {
-      output = output.replaceAll(
-        STRING_TEMPLATE('cookies', cookieName),
-        cookieValue,
-      )
-    }
+    output = output.replaceAll(
+      STRING_TEMPLATE('cookies', cookieName),
+      // We fallback to an empty string to avoid sending the internal
+      // template format ('{{ cookies.<cookie> }}') to other services/APIs
+      cookieValue ?? '',
+    )
   }
   return output
 }


### PR DESCRIPTION
Please see https://discord.com/channels/972416966683926538/1367991950418116618/1368839273738141820

We should avoid forwarding our internal cookies template format for `Authorization` headers etc. Instead, I suggest we replace it with an empty string if a cookie doesn't exist (has expired). In the editor, I suggest we use the `Get Cookie` formula to determine if a cookie exists, and if it doesn't we should return `null` for the `Authorization` header value (during SSR).