### PR TITLE
Force the cursor to always be within the dragged element

### DIFF
--- a/packages/runtime/src/editor-preview.main.ts
+++ b/packages/runtime/src/editor-preview.main.ts
@@ -533,6 +533,14 @@ export const createRoot = (
               dragState.initialContainer.getBoundingClientRect(),
               { x, y },
             )
+
+            // Move the element towards the cursor when out of bounds
+            const rect = dragState.element.getBoundingClientRect()
+            if (!rectHasPoint(rect, { x, y })) {
+              dragState.offset.x -= (x - (rect.left + rect.width / 2)) * 0.1
+              dragState.offset.y -= (y - (rect.top + rect.height / 2)) * 0.1
+            }
+
             if (draggingInsideContainer && !metaKey) {
               dragReorder(dragState)
             } else {


### PR DESCRIPTION
Small improvement to drag and drop. Sometimes when dragging an element, and that element would greatly change the layout of the page, the dragging-point could move outside the element. This change makes it so the dragged element will move towards the cursor in such events.