### PR TITLE
Adjust arguments for validateUrl

### DIFF
--- a/examples/hono/src/routes/apiProxy.ts
+++ b/examples/hono/src/routes/apiProxy.ts
@@ -13,9 +13,16 @@ export const proxyRequestHandler = async (
 ): Promise<Response> => {
   const req = c.req.raw
   const requestCookies = getRequestCookies(req)
+  const requestUrl = new URL(req.url)
   const outgoingRequestUrl = validateUrl(
     // Replace potential cookie values in the URL
-    applyTemplateValues(req.headers.get(PROXY_URL_HEADER), requestCookies),
+    {
+      path: applyTemplateValues(
+        req.headers.get(PROXY_URL_HEADER),
+        requestCookies,
+      ),
+      origin: requestUrl.origin,
+    },
   )
   if (!outgoingRequestUrl) {
     return c.json(

--- a/examples/hono/src/routes/favicon.ts
+++ b/examples/hono/src/routes/favicon.ts
@@ -11,7 +11,11 @@ export const favicon = async (c: Context<HonoEnv>) => {
       c.var.project.files.config?.meta?.icon?.formula,
       undefined as any,
     )
-    const validIconUrl = validateUrl(iconUrl)
+    const requestUrl = new URL(c.req.url)
+    const validIconUrl = validateUrl({
+      path: iconUrl,
+      origin: requestUrl.origin,
+    })
     if (validIconUrl) {
       // return a (streamed) response with the icon
       const { body, ok, headers: iconHeaders } = await fetch(validIconUrl)

--- a/examples/hono/src/routes/manifest.ts
+++ b/examples/hono/src/routes/manifest.ts
@@ -12,7 +12,11 @@ export const manifest = async (c: Context<HonoEnv>) => {
       c.var.project.files.config?.meta?.manifest?.formula,
       undefined as any,
     )
-    const validManifestUrl = validateUrl(manifestUrl)
+    const requestUrl = new URL(c.req.url)
+    const validManifestUrl = validateUrl({
+      path: manifestUrl,
+      origin: requestUrl.origin,
+    })
     if (typeof validManifestUrl === 'string') {
       // return a (streamed) response with the body from the manifest file
       const { body, ok } = await fetch(manifestUrl)

--- a/examples/hono/src/routes/robots.ts
+++ b/examples/hono/src/routes/robots.ts
@@ -11,7 +11,11 @@ export const robots = async (c: Context<HonoEnv>) => {
     const robots = c.var.project.files.config?.meta?.robots
     // we don't provide a context below, as the formula should just be a value formula
     const robotsUrl = applyFormula(robots?.formula, undefined as any)
-    const validatedRobotsUrl = validateUrl(robotsUrl)
+    const requestUrl = new URL(c.req.url)
+    const validatedRobotsUrl = validateUrl({
+      path: robotsUrl,
+      origin: requestUrl.origin,
+    })
     if (validatedRobotsUrl) {
       // return a (streamed) response with the body from robots.txt
       const { body, ok } = await fetch(validatedRobotsUrl)

--- a/examples/hono/src/routes/serviceWorker.ts
+++ b/examples/hono/src/routes/serviceWorker.ts
@@ -12,7 +12,11 @@ export const serviceWorker = async (c: Context<HonoEnv>) => {
       ? // We don't need to provide a context for applyFormula, as the formula should just be a value formula
         applyFormula(config.meta.serviceWorker.formula, undefined as any)
       : undefined
-    const url = validateUrl(serviceWorkerUrl)
+    const requestUrl = new URL(c.req.url)
+    const url = validateUrl({
+      path: serviceWorkerUrl,
+      origin: requestUrl.origin,
+    })
     if (url) {
       // return a (streamed) response with the body from the service worker
       const { body, ok } = await fetch(url)

--- a/examples/hono/src/routes/sitemap.ts
+++ b/examples/hono/src/routes/sitemap.ts
@@ -15,9 +15,13 @@ export const sitemap = async (c: Context<HonoEnv>) => {
     const project = c.var.project
     const sitemapFormula = project.files.config?.meta?.sitemap?.formula
     if (isDefined(sitemapFormula)) {
+      const requestUrl = new URL(c.req.url)
       const sitemapUrl = validateUrl(
         // we don't provide a context for applyFormula, as the formula should just be a value formula
-        applyFormula(sitemapFormula, undefined as any),
+        {
+          path: applyFormula(sitemapFormula, undefined as any),
+          origin: requestUrl.origin,
+        },
       )
       if (sitemapUrl) {
         // return a (streamed) response with the body from sitemap.xml

--- a/examples/hono/src/utils/api.ts
+++ b/examples/hono/src/utils/api.ts
@@ -284,7 +284,10 @@ const fetchApiV2 = async ({
       },
     })
     if (typeof location === 'string') {
-      const url = validateUrl(location, originalRequestUrl.origin)
+      const url = validateUrl({
+        path: location,
+        origin: originalRequestUrl.origin,
+      })
       if (url) {
         // Opt out early to avoid additional API requests/rendering
         throw new RedirectError({

--- a/packages/backend/src/routes/apiProxy.ts
+++ b/packages/backend/src/routes/apiProxy.ts
@@ -13,9 +13,16 @@ export const proxyRequestHandler = async (
 ): Promise<Response> => {
   const req = c.req.raw
   const requestCookies = getRequestCookies(req)
+  const requestUrl = new URL(req.url)
   const outgoingRequestUrl = validateUrl(
     // Replace potential cookie values in the URL
-    applyTemplateValues(req.headers.get(PROXY_URL_HEADER), requestCookies),
+    {
+      path: applyTemplateValues(
+        req.headers.get(PROXY_URL_HEADER),
+        requestCookies,
+      ),
+      origin: requestUrl.origin,
+    },
   )
   if (!outgoingRequestUrl) {
     return c.json(

--- a/packages/backend/src/routes/favicon.ts
+++ b/packages/backend/src/routes/favicon.ts
@@ -11,7 +11,11 @@ export const favicon = async (c: Context<HonoEnv<HonoProject>>) => {
       c.var.config?.meta?.icon?.formula,
       undefined as any,
     )
-    const validIconUrl = validateUrl(iconUrl)
+    const requestUrl = new URL(c.req.url)
+    const validIconUrl = validateUrl({
+      path: iconUrl,
+      origin: requestUrl.origin,
+    })
     if (validIconUrl) {
       // return a (streamed) response with the icon
       const { body, ok, headers: iconHeaders } = await fetch(validIconUrl)

--- a/packages/core/src/utils/url.test.ts
+++ b/packages/core/src/utils/url.test.ts
@@ -3,15 +3,34 @@ import { validateUrl } from './url'
 
 describe('validateUrl()', () => {
   test('it validates urls correctly', () => {
-    expect(validateUrl('https://toddle.dev')).toBeInstanceOf(URL)
-    expect(validateUrl('not-a-url')).toBe(false)
+    expect(
+      validateUrl({ path: 'https://nordcraft.com', origin: undefined }),
+    ).toBeInstanceOf(URL)
+    expect(validateUrl({ path: 'not-a-url', origin: undefined })).toBe(false)
   })
 
   test('it validates urls arrays in query params correctly', async () => {
-    const url = validateUrl('https://toddle.dev?test=1&test=2')
+    const url = validateUrl({
+      path: 'https://nordcraft.com?test=1&test=2',
+      origin: undefined,
+    })
     expect(url).toBeInstanceOf(URL)
     if (url instanceof URL) {
       expect(url.searchParams.getAll('test')).toEqual(['1', '2'])
     }
+  })
+
+  test('it validates relative urls when a base is provided', () => {
+    const url = validateUrl({
+      path: '/my-path',
+      origin: 'https://nordcraft.com',
+    })
+    expect(url).toBeInstanceOf(URL)
+    expect((url as URL).href).toBe('https://nordcraft.com/my-path')
+  })
+
+  test("it doesn't accept relative urls when no base is provided", () => {
+    const url = validateUrl({ path: '/my-path', origin: undefined })
+    expect(url).toBe(false)
   })
 })

--- a/packages/core/src/utils/url.ts
+++ b/packages/core/src/utils/url.ts
@@ -6,13 +6,18 @@ export const isLocalhostUrl = (hrefOrOrigin: string) =>
 export const isLocalhostHostname = (hostname: string) =>
   hostname === 'localhost' || hostname === '127.0.0.1'
 
-export const validateUrl = (url?: string | null, base?: string) => {
-  if (typeof url !== 'string') {
+export const validateUrl = ({
+  path,
+  origin,
+}: {
+  path: string | null | undefined
+  origin: string | undefined
+}) => {
+  if (typeof path !== 'string') {
     return false
   }
-
   try {
-    const urlObject = new URL(url, base)
+    const urlObject = new URL(path, origin)
     // Creating a new URL object will not correctly encode the search params
     // So we need to iterate over them to make sure they are encoded as that happens when setting them explicitly
     const searchCopy = new URLSearchParams(urlObject.searchParams)

--- a/packages/runtime/src/api/createAPIv2.ts
+++ b/packages/runtime/src/api/createAPIv2.ts
@@ -118,7 +118,10 @@ export function createAPI(
         },
       })
       if (typeof location === 'string') {
-        const url = validateUrl(location, window.location.href)
+        const url = validateUrl({
+          path: location,
+          origin: window.location.origin,
+        })
         if (url) {
           if (ctx.env.runtime === 'preview') {
             // Attempt to notify the parent about the failed navigation attempt

--- a/packages/ssr/src/rendering/head.ts
+++ b/packages/ssr/src/rendering/head.ts
@@ -164,9 +164,10 @@ export const getHeadItems = ({
       )}" />`,
     )
   }
-  const manifestUrl = validateUrl(
-    applyFormula(files.config?.meta?.manifest?.formula, context),
-  )
+  const manifestUrl = validateUrl({
+    path: applyFormula(files.config?.meta?.manifest?.formula, context),
+    origin: url.origin,
+  })
   if (manifestUrl) {
     const manifestUrl = urlWithCacheBuster('/manifest.json', cacheBuster)
     headItems.set(


### PR DESCRIPTION
This should ensure that we remember to pass a hostname to the `validateUrl` function when available.