### PR TITLE
Prefer static parts over shorter routes in routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nordcraft",
   "type": "module",
   "license": "Apache-2.0",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "homepage": "https://github.com/nordcraftengine/nordcraft",
   "private": "false",
   "workspaces": [

--- a/packages/ssr/src/routing/routing.test.ts
+++ b/packages/ssr/src/routing/routing.test.ts
@@ -64,6 +64,55 @@ describe('matchPageForUrl', () => {
       pages[4],
     )
   })
+  test('it prefers static path segments in urls', () => {
+    const routes: PageRoute['path'][] = [
+      [
+        // /:other/:page
+        { type: 'param', name: 'other', testValue: '' },
+        { type: 'param', name: 'page', testValue: '' },
+      ],
+      [
+        // /guides/:p1/:p2
+        { type: 'static', name: 'guides' },
+        { type: 'param', name: 'p1', testValue: '' },
+        { type: 'param', name: 'p2', testValue: '' },
+      ],
+    ]
+
+    const pages: ProjectFiles['components'] = Object.fromEntries(
+      routes.map((path, i): [string, PageComponent] => [
+        `${i}`,
+        {
+          name: `page-${i}`,
+          attributes: {},
+          variables: {},
+          apis: {},
+          nodes: {},
+          route: { path, query: {} },
+        },
+      ]),
+    )
+    const guidesUrl = new URL('http://localhost:3000/guides/category/explore')
+    expect(matchPageForUrl({ url: guidesUrl, components: pages })).toEqual(
+      pages[1],
+    )
+    const guidesUrl2 = new URL('http://localhost:3000/guides')
+    expect(matchPageForUrl({ url: guidesUrl2, components: pages })).toEqual(
+      pages[1],
+    )
+    const guidesUrl3 = new URL('http://localhost:3000/test')
+    expect(matchPageForUrl({ url: guidesUrl3, components: pages })).toEqual(
+      pages[0],
+    )
+    const guidesUrl4 = new URL('http://localhost:3000/test/hello')
+    expect(matchPageForUrl({ url: guidesUrl4, components: pages })).toEqual(
+      pages[0],
+    )
+    const guidesUrl5 = new URL('http://localhost:3000/test/hello/world')
+    expect(
+      matchPageForUrl({ url: guidesUrl5, components: pages }),
+    ).toBeUndefined()
+  })
   test('it does not find a match for unknown paths', () => {
     const routes: PageRoute['path'][] = [
       // /search

--- a/packages/ssr/src/routing/routing.test.ts
+++ b/packages/ssr/src/routing/routing.test.ts
@@ -1,112 +1,118 @@
 import { describe, expect, test } from '@jest/globals'
-import type {
-  PageComponent,
-  PageRoute,
-} from '@nordcraft/core/dist/component/component.types'
-import type { ProjectFiles } from '../ssr.types'
+import type { RouteDeclaration } from '@nordcraft/core/dist/component/component.types'
 import { matchPageForUrl } from './routing'
 
 describe('matchPageForUrl', () => {
   test('it finds the correct page for a url', () => {
-    const routes: PageRoute['path'][] = [
-      // /search
-      [{ type: 'static', name: 'search' }],
-      // /:category
-      [{ type: 'param', testValue: '', name: 'category' }],
-      [
-        // /docs/:docs-page
-        { type: 'static', name: 'docs' },
-        { type: 'param', testValue: '', name: 'docs-page' },
-      ],
-      [
-        // /:test/hello
-        { type: 'param', name: 'test', testValue: '' },
-        { type: 'static', name: 'hello' },
-      ],
-      [
-        // /:other/:page
-        { type: 'param', name: 'other', testValue: '' },
-        { type: 'param', name: 'page', testValue: '' },
-      ],
-    ]
-
-    const pages: ProjectFiles['components'] = Object.fromEntries(
-      routes.map((path, i): [string, PageComponent] => [
-        `${i}`,
-        {
-          name: `page-${i}`,
-          attributes: {},
-          variables: {},
-          apis: {},
-          nodes: {},
-          route: { path, query: {} },
+    const pages: Record<
+      string,
+      {
+        route?: RouteDeclaration | null
+      }
+    > = {
+      searchPage: {
+        route: { path: [{ type: 'static', name: 'search' }], query: {} },
+      },
+      categoryPage: {
+        route: {
+          path: [{ type: 'param', name: 'category', testValue: 'fruit' }],
+          query: {},
         },
-      ]),
-    )
+      },
+      docsPage: {
+        route: {
+          path: [
+            { type: 'static', name: 'docs' },
+            { type: 'param', testValue: '', name: 'docs-page' },
+          ],
+          query: {},
+        },
+      },
+      helloPage: {
+        route: {
+          path: [
+            { type: 'param', name: 'test', testValue: '' },
+            { type: 'static', name: 'hello' },
+          ],
+          query: {},
+        },
+      },
+      otherPage: {
+        route: {
+          path: [
+            { type: 'param', name: 'other', testValue: '' },
+            { type: 'param', name: 'page', testValue: '' },
+          ],
+          query: {},
+        },
+      },
+    }
+
     const searchUrl = new URL('http://localhost:3000/search')
     expect(matchPageForUrl({ url: searchUrl, components: pages })).toEqual(
-      pages[0],
+      pages['searchPage'],
     )
     const categoryUrl = new URL('http://localhost:3000/fruit')
     expect(matchPageForUrl({ url: categoryUrl, components: pages })).toEqual(
-      pages[1],
+      pages['categoryPage'],
     )
     const docsUrl = new URL('http://localhost:3000/docs/intro')
     expect(matchPageForUrl({ url: docsUrl, components: pages })).toEqual(
-      pages[2],
+      pages['docsPage'],
     )
     const helloUrl = new URL('http://localhost:3000/bla/hello')
     expect(matchPageForUrl({ url: helloUrl, components: pages })).toEqual(
-      pages[3],
+      pages['helloPage'],
     )
     const otherUrl = new URL('http://localhost:3000/hello/world')
     expect(matchPageForUrl({ url: otherUrl, components: pages })).toEqual(
-      pages[4],
+      pages['otherPage'],
     )
   })
   test('it prefers static path segments in urls', () => {
-    const routes: PageRoute['path'][] = [
-      [
-        // /:other/:page
-        { type: 'param', name: 'other', testValue: '' },
-        { type: 'param', name: 'page', testValue: '' },
-      ],
-      [
-        // /guides/:p1/:p2
-        { type: 'static', name: 'guides' },
-        { type: 'param', name: 'p1', testValue: '' },
-        { type: 'param', name: 'p2', testValue: '' },
-      ],
-    ]
-
-    const pages: ProjectFiles['components'] = Object.fromEntries(
-      routes.map((path, i): [string, PageComponent] => [
-        `${i}`,
-        {
-          name: `page-${i}`,
-          attributes: {},
-          variables: {},
-          apis: {},
-          nodes: {},
-          route: { path, query: {} },
+    const pages: Record<
+      string,
+      {
+        route?: RouteDeclaration | null
+      }
+    > = {
+      otherPage: {
+        route: {
+          path: [
+            // /:other/:page
+            { type: 'param', name: 'other', testValue: '' },
+            { type: 'param', name: 'page', testValue: '' },
+          ],
+          query: {},
         },
-      ]),
-    )
+      },
+      guidesPage: {
+        route: {
+          path: [
+            // /guides/:p1/:p2
+            { type: 'static', name: 'guides' },
+            { type: 'param', name: 'p1', testValue: '' },
+            { type: 'param', name: 'p2', testValue: '' },
+          ],
+          query: {},
+        },
+      },
+    }
     const guidesUrl = new URL('http://localhost:3000/guides/category/explore')
     expect(matchPageForUrl({ url: guidesUrl, components: pages })).toEqual(
-      pages[1],
+      pages['guidesPage'],
     )
     const guidesUrl2 = new URL('http://localhost:3000/guides')
     expect(matchPageForUrl({ url: guidesUrl2, components: pages })).toEqual(
-      pages[1],
+      pages['guidesPage'],
     )
     const guidesUrl3 = new URL('http://localhost:3000/test')
     expect(matchPageForUrl({ url: guidesUrl3, components: pages })).toEqual(
-      pages[0],
+      pages['otherPage'],
     )
     const guidesUrl4 = new URL('http://localhost:3000/test/hello')
     expect(matchPageForUrl({ url: guidesUrl4, components: pages })).toEqual(
-      pages[0],
+      pages['otherPage'],
     )
     const guidesUrl5 = new URL('http://localhost:3000/test/hello/world')
     expect(
@@ -114,28 +120,29 @@ describe('matchPageForUrl', () => {
     ).toBeUndefined()
   })
   test('it does not find a match for unknown paths', () => {
-    const routes: PageRoute['path'][] = [
-      // /search
-      [{ type: 'static', name: 'search' }],
-      [
-        // /:other/page
-        { type: 'param', name: 'other', testValue: '' },
-        { type: 'static', name: 'page' },
-      ],
-    ]
-    const pages: ProjectFiles['components'] = Object.fromEntries(
-      routes.map((path, i): [string, PageComponent] => [
-        `${i}`,
-        {
-          name: `page-${i}`,
-          attributes: {},
-          variables: {},
-          apis: {},
-          nodes: {},
-          route: { path, query: {} },
+    const pages: Record<
+      string,
+      {
+        route?: RouteDeclaration | null
+      }
+    > = {
+      otherPage: {
+        route: {
+          path: [{ type: 'static', name: 'search' }],
+          query: {},
         },
-      ]),
-    )
+      },
+      guidesPage: {
+        route: {
+          path: [
+            // /:other/page
+            { type: 'param', name: 'other', testValue: '' },
+            { type: 'static', name: 'page' },
+          ],
+          query: {},
+        },
+      },
+    }
     const categoryUrl = new URL('http://localhost:3000/fruit')
     expect(
       matchPageForUrl({ url: categoryUrl, components: pages }),

--- a/packages/ssr/src/routing/routing.ts
+++ b/packages/ssr/src/routing/routing.ts
@@ -49,7 +49,7 @@ export const matchRoutes = <T>({
 }): T | undefined => {
   const pathSegments = getPathSegments(url)
   // E.g. /fruit/:fruitId => 1.2
-  // E.g. /:blog/:slug => 2.2
+  // E.g. /:blog/:slug/:author => 2.2.2
   // E.g. /:dynamic/static => 2.1
   const getPathHash = (path: PageRoute['path']) =>
     path.map((segment) => (segment.type === 'static' ? '1' : '2')).join('.')
@@ -71,6 +71,7 @@ export const matchRoutes = <T>({
       const routeBHash = getPathHash(getRoute(b).path)
       // Favors static segments over dynamic segments and shorter paths over longer paths
       // E.g. /fruit/:fruitId wins over /:blog/:slug for /fruit/apple
+      // E.g. /fruit/:fruitId/:category wins over /:blog/:slug for /fruit/apple
       return routeAHash.localeCompare(routeBHash)
     })
   return matches[0]

--- a/packages/ssr/src/routing/routing.ts
+++ b/packages/ssr/src/routing/routing.ts
@@ -64,6 +64,16 @@ export const matchRoutes = <T>({
     .sort((a, b) => {
       const routeA = getRoute(a)
       const routeB = getRoute(b)
+      const staticSegmentsA = routeA.path.filter(
+        (segment) => segment.type === 'static',
+      ).length
+      const staticSegmentsB = routeB.path.filter(
+        (segment) => segment.type === 'static',
+      ).length
+      // Prefer routes with more static segments (hence static matches)
+      if (staticSegmentsA !== staticSegmentsB) {
+        return staticSegmentsB - staticSegmentsA
+      }
       // Prefer shorter routes
       const diff = routeA.path.length - routeB.path.length
       if (diff !== 0) {


### PR DESCRIPTION
Today, a request for `/guides/my-guide` would be preferred by the route `/:p1/:p2` over `/guides/:p1/:p2` since the first route is shorter. I would expect the route with most static matches to be preferred - alternatively the one with the most static matches before a dynamic match.

This change is technically a **breaking change**, but I haven't found any projects/pages that would be affected.

See reported issue here https://discord.com/channels/972416966683926538/1361298333821571316/1361339763826622626