### PR TITLE
Adjust default request body content type

### DIFF
--- a/packages/core/src/api/api.test.ts
+++ b/packages/core/src/api/api.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, test } from '@jest/globals'
-import { valueFormula } from '../formula/formulaUtils'
+import { pathFormula, valueFormula } from '../formula/formulaUtils'
 import {
   createApiRequest,
+  getRequestBody,
   getRequestHeaders,
   getRequestPath,
   getRequestQueryParams,
@@ -314,6 +315,83 @@ describe('createApiRequest', () => {
     )
     expect(request.headers.get('Content-Type')).toBe('application/json')
   })
-
-  // TODO: Add tests for the http body
+})
+describe('getRequestBody', () => {
+  it('defaults to a JSON encoded body', () => {
+    const apiRequest: ApiRequest = {
+      name: 'Test API',
+      type: 'http',
+      version: 2,
+      inputs: {},
+      body: {
+        type: 'object',
+        arguments: [{ name: 'key', formula: valueFormula('value') }],
+      },
+    }
+    const body = getRequestBody({
+      api: apiRequest,
+      formulaContext: undefined as any,
+      headers: new Headers(),
+      method: ApiMethod.POST,
+    })
+    expect(body).toBe('{"key":"value"}')
+  })
+  it('supports url encoded bodies', () => {
+    const apiRequest: ApiRequest = {
+      name: 'Test API',
+      type: 'http',
+      version: 2,
+      inputs: {},
+      body: {
+        type: 'object',
+        arguments: [{ name: 'key', formula: valueFormula('value') }],
+      },
+    }
+    const body = getRequestBody({
+      api: apiRequest,
+      formulaContext: undefined as any,
+      headers: new Headers([
+        ['Content-Type', 'application/x-www-form-urlencoded'],
+      ]),
+      method: ApiMethod.POST,
+    })
+    expect(body).toBe('key=value')
+  })
+  it('supports form data', () => {
+    const apiRequest: ApiRequest = {
+      name: 'Test API',
+      type: 'http',
+      version: 2,
+      inputs: {},
+      body: {
+        type: 'object',
+        arguments: [{ name: 'key', formula: valueFormula('value') }],
+      },
+    }
+    const body = getRequestBody({
+      api: apiRequest,
+      formulaContext: undefined as any,
+      headers: new Headers([['Content-Type', 'multipart/form-data']]),
+      method: ApiMethod.POST,
+    })
+    expect(body).toBeInstanceOf(FormData)
+  })
+  it('respects other content-types', () => {
+    const apiRequest: ApiRequest = {
+      name: 'Test API',
+      type: 'http',
+      version: 2,
+      inputs: {},
+      body: pathFormula(['Variables', 'file']),
+    }
+    const body = getRequestBody({
+      api: apiRequest,
+      formulaContext: {
+        data: { Variables: { file: new File([], 'test.jpg') } },
+      } as any,
+      headers: new Headers([['Content-Type', 'image/jpeg']]),
+      method: ApiMethod.POST,
+    })
+    expect(body).toBeInstanceOf(File)
+  })
 })

--- a/packages/core/src/api/api.ts
+++ b/packages/core/src/api/api.ts
@@ -12,6 +12,7 @@ import type {
   ToddleRequestInit,
 } from './apiTypes'
 import { ApiMethod } from './apiTypes'
+import { isJsonHeader } from './headers'
 import { LegacyToddleApi } from './LegacyToddleApi'
 import { ToddleApiV2 } from './ToddleApiV2'
 
@@ -289,7 +290,7 @@ export const isApiError = ({
   return toBoolean(errorFormulaRes)
 }
 
-const getRequestBody = ({
+export const getRequestBody = ({
   api,
   formulaContext,
   headers,
@@ -308,7 +309,12 @@ const getRequestBody = ({
   if (!body) {
     return
   }
-  switch (headers.get('content-type')) {
+  const contentType = headers.get('content-type')
+  if (isJsonHeader(contentType)) {
+    // JSON.stringify the body if the content type is JSON
+    return JSON.stringify(body)
+  }
+  switch (contentType) {
     case 'application/x-www-form-urlencoded': {
       if (typeof body === 'object' && body !== null) {
         return Object.entries(body)
@@ -340,8 +346,12 @@ const getRequestBody = ({
     }
     case 'text/plain':
       return String(body)
-    default:
+    // When no content-type is specified, we assume the body is JSON
+    case null:
       return JSON.stringify(body)
+    default:
+      // For other content types, we return the body as is
+      return body
   }
 }
 


### PR DESCRIPTION
Currently, we only support FormData, URL encoding, JSON, and text as content-type for API requests. However, if a different content-type has been specified, we should not try to json encode the request body.
In order to make this a smaller breaking change than it could be, we should still default to json encoding the request body if no content-type is specified (when it's null). If it's specified and its none of the above though, we should not try to encode the request body.