### PR TITLE
Fixed an issue with even-child selector not working as expected

### DIFF
--- a/packages/core/src/styling/variantSelector.ts
+++ b/packages/core/src/styling/variantSelector.ts
@@ -38,7 +38,7 @@ type MediaQuery = {
 
 export interface StyleVariant {
   autofill?: boolean
-  'even-child'?: boolean
+  'nth-child(even)'?: boolean
   'first-child'?: boolean
   'first-of-type'?: boolean
   'focus-visible'?: boolean
@@ -144,7 +144,7 @@ export type SlotNodeModel = {
 export const variantSelector = (variant: StyleVariant) =>
   [
     (variant.className ?? variant['class']) && `.${variant.className}`,
-    (variant.evenChild ?? variant['even-child']) && ':nth-child(even)',
+    (variant.evenChild ?? variant['nth-child(even)']) && ':nth-child(even)',
     (variant.firstChild ?? variant['first-child']) && ':first-child',
     (variant.focusWithin ?? variant['focus-within']) && ':focus-within',
     (variant.lastChild ?? variant['last-child']) && ':last-child',

--- a/packages/core/src/styling/variantSelector.ts
+++ b/packages/core/src/styling/variantSelector.ts
@@ -39,6 +39,7 @@ type MediaQuery = {
 export interface StyleVariant {
   autofill?: boolean
   'nth-child(even)'?: boolean
+  'even-child'?: boolean
   'first-child'?: boolean
   'first-of-type'?: boolean
   'focus-visible'?: boolean
@@ -144,7 +145,10 @@ export type SlotNodeModel = {
 export const variantSelector = (variant: StyleVariant) =>
   [
     (variant.className ?? variant['class']) && `.${variant.className}`,
-    (variant.evenChild ?? variant['nth-child(even)']) && ':nth-child(even)',
+    (variant.evenChild ??
+      variant['even-child'] ??
+      variant['nth-child(even)']) &&
+      ':nth-child(even)',
     (variant.firstChild ?? variant['first-child']) && ':first-child',
     (variant.focusWithin ?? variant['focus-within']) && ':focus-within',
     (variant.lastChild ?? variant['last-child']) && ':last-child',


### PR DESCRIPTION
Fixed an issue where using the `even-child` selector in the editor would not apply the selector.

I tested on this branch https://tester-jacob_test.toddle.site/repeat (each even card should have a lighter background color).