### PR TITLE
Omit browser bug and improve performance by not transitioning out of bounds elements

### DIFF
--- a/packages/runtime/src/editor/drag-drop/dragEnded.ts
+++ b/packages/runtime/src/editor/drag-drop/dragEnded.ts
@@ -1,3 +1,4 @@
+import { isElementInViewport } from '../../utils/isElementInViewport'
 import { tryStartViewTransition } from '../../utils/tryStartViewTransition'
 import type { DragState } from '../types'
 import { DRAG_MOVE_CLASSNAME } from './dragMove'
@@ -18,14 +19,14 @@ export async function dragEnded(dragState: DragState, canceled: boolean) {
     'dropped-item-self',
   )
   siblings.forEach((node, i) => {
-    if (node instanceof HTMLElement) {
+    if (node instanceof HTMLElement && isElementInViewport(node)) {
       node.style.setProperty(
         'view-transition-name',
         'dropped-item-sibling-' + i,
       )
     }
   })
-  dragState.repeatedNodes.forEach((node, i) => {
+  dragState.repeatedNodes.filter(isElementInViewport).forEach((node, i) => {
     node.style.setProperty('view-transition-name', 'dropped-item-repeated-' + i)
   })
   await tryStartViewTransition(() => {

--- a/packages/runtime/src/editor/drag-drop/dragReorder.ts
+++ b/packages/runtime/src/editor/drag-drop/dragReorder.ts
@@ -1,3 +1,4 @@
+import { isElementInViewport } from '../../utils/isElementInViewport'
 import { tryStartViewTransition } from '../../utils/tryStartViewTransition'
 import type { DragState } from '../types'
 import { DRAG_MOVE_CLASSNAME } from './dragMove'
@@ -50,11 +51,12 @@ export function dragReorder(dragState: DragState | null) {
   ) {
     dragState.isTransitioning = true
     const siblings = Array.from(dragState.initialContainer.childNodes)
-    siblings.forEach((sibling, i) => {
-      if (sibling instanceof HTMLElement) {
+    siblings
+      .filter((sibling) => sibling instanceof HTMLElement)
+      .filter(isElementInViewport)
+      .forEach((sibling, i) => {
         sibling.style.setProperty('view-transition-name', 'item-' + i)
-      }
-    })
+      })
     dragState.element.style.setProperty('view-transition-name', '__drag-item')
 
     const prevLeft = dragState.element.offsetLeft

--- a/packages/runtime/src/utils/isElementInViewport.ts
+++ b/packages/runtime/src/utils/isElementInViewport.ts
@@ -1,0 +1,14 @@
+export function isElementInViewport(element: HTMLElement, offset = 0): boolean {
+  const rect = element.getBoundingClientRect()
+  const viewportHeight =
+    window.innerHeight || document.documentElement.clientHeight
+  const viewportWidth =
+    window.innerWidth || document.documentElement.clientWidth
+
+  return (
+    rect.top >= 0 - offset &&
+    rect.left >= 0 - offset &&
+    rect.bottom <= viewportHeight + offset &&
+    rect.right <= viewportWidth + offset
+  )
+}


### PR DESCRIPTION
There might be some paint crashing issues in Chromium browsers around view transition of elements inside an iframe, but out of bounds of their viewport. This change should improve performance for extreme cases either way performance.