### PR TITLE
Enable html-eslint

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,8 @@
     "": {
       "devDependencies": {
         "@eslint/js": "9.26.0",
+        "@html-eslint/eslint-plugin": "^0.40.3",
+        "@html-eslint/parser": "^0.40.0",
         "@octokit/core": "6.1.5",
         "@types/jest": "29.5.14",
         "@typescript-eslint/eslint-plugin": "8.32.1",
@@ -237,6 +239,14 @@
     "@fastify/busboy": ["@fastify/busboy@2.1.1", "", {}, "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="],
 
     "@happy-dom/global-registrator": ["@happy-dom/global-registrator@17.4.7", "", { "dependencies": { "happy-dom": "^17.4.7" } }, "sha512-BsKWeI115LT0J/lKJ4Kz638oy4zO+nC4TLh3cYPY6BBypttPZg8Fg+EXL2If4KHMSy3Wx+yRiM+68Hr1iGgiWA=="],
+
+    "@html-eslint/eslint-plugin": ["@html-eslint/eslint-plugin@0.40.3", "", { "dependencies": { "@eslint/plugin-kit": "0.2.8", "@html-eslint/parser": "^0.40.0", "@html-eslint/template-parser": "^0.40.0", "@html-eslint/template-syntax-parser": "^0.40.0" } }, "sha512-ju0BTpo60/NOqh2VIQzBz2d+cekzmvqJZ2BHFRfg3oDQqWzp8nIrgNiKws0ILfs82su/w4zZBqKtMMQp4WvsvQ=="],
+
+    "@html-eslint/parser": ["@html-eslint/parser@0.40.0", "", { "dependencies": { "@html-eslint/template-syntax-parser": "^0.40.0", "es-html-parser": "0.2.0" } }, "sha512-xvySQLPogafK2aTOPBD6V7+4qpr1AnOZXO8zM2z0b4i3BB9ISk5PTWu5+ofOekKxjxUh7Z+QWaoezu1SIi33YA=="],
+
+    "@html-eslint/template-parser": ["@html-eslint/template-parser@0.40.0", "", { "dependencies": { "es-html-parser": "0.2.0" } }, "sha512-f1S70T88yRe3zStT0CiDDgRw24Fgi1wgbW74YNUocEVuXvh2snxBEufY46Yg2udGlOz+SnQaygshacW45L+JWw=="],
+
+    "@html-eslint/template-syntax-parser": ["@html-eslint/template-syntax-parser@0.40.0", "", {}, "sha512-Rq3UmjiWreKnXrN95Nt6vLlKgQrV8PhoYrlADn3u7X7vtgCccTmjV6aUHJCw7AyNXmcSNNpN2KPsBmQfH3y58A=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
@@ -559,6 +569,8 @@
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-html-parser": ["es-html-parser@0.2.0", "", {}, "sha512-snJ7uJC8Dkx/yT0eYZrWcY57rkPU6Zui6YphPynw8r52AWf57gjqMC0GWe7OxSDipwXowFpa3rqckEeAPTOz7w=="],
 
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,8 +1,10 @@
 import { FlatCompat } from '@eslint/eslintrc'
 import js from '@eslint/js'
+import html from '@html-eslint/eslint-plugin'
 import typescriptEslint from '@typescript-eslint/eslint-plugin'
 import tsParser from '@typescript-eslint/parser'
 import inclusiveLanguage from 'eslint-plugin-inclusive-language'
+import { defineConfig } from 'eslint/config'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -14,7 +16,15 @@ const compat = new FlatCompat({
   allConfig: js.configs.all,
 })
 
-export default [
+export default defineConfig([
+  {
+    ...html.configs['flat/recommended'],
+    files: ['**/*.html', '**/*.ts'],
+    rules: {
+      ...html.configs['flat/recommended'].rules, // Must be defined. If not, all recommended rules will be lost
+      '@html-eslint/indent': ['error', 2],
+    },
+  },
   {
     ignores: [
       '**/node_modules/',
@@ -80,4 +90,4 @@ export default [
       'no-console': 'error',
     },
   },
-]
+])

--- a/package.json
+++ b/package.json
@@ -10,16 +10,18 @@
   ],
   "devDependencies": {
     "@eslint/js": "9.26.0",
+    "@html-eslint/eslint-plugin": "^0.40.3",
+    "@html-eslint/parser": "^0.40.0",
     "@octokit/core": "6.1.5",
+    "@types/jest": "29.5.14",
     "@typescript-eslint/eslint-plugin": "8.32.1",
     "@typescript-eslint/parser": "8.32.1",
-    "@types/jest": "29.5.14",
     "esbuild": "0.25.4",
-    "eslint": "9.26.0",
     "eslint-plugin-inclusive-language": "2.2.1",
+    "eslint": "9.26.0",
     "jest": "29.7.0",
-    "prettier": "3.5.3",
     "prettier-plugin-organize-imports": "4.1.0",
+    "prettier": "3.5.3",
     "typescript": "5.8.3"
   },
   "scripts": {


### PR DESCRIPTION
See https://eslint.org/blog/2025/05/eslint-html-plugin/ 🎉
Eventually, we could output a few html files during build and lint those to ensure they don't have any errors (that the linter knows about).