### PR TITLE
Group dependencies for dependabot+update schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,5 +4,17 @@ updates:
   - package-ecosystem: 'bun'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
     open-pull-requests-limit: 5
+    groups:
+      linting:
+        patterns:
+          - '*eslint*'
+          - 'eslint'
+          - 'eslint*'
+        formatting:
+          - 'prettier'
+          - 'prettier-plugin-organize-imports'
+        test:
+          - 'jest'
+          - '@types/jest'


### PR DESCRIPTION
To reduce the amount of dependabot PRs, we can group dependencies together. See more here https://github.blog/changelog/2023-06-29-grouped-version-updates-for-dependabot-public-beta/