### PR TITLE
Remove pipe from string or array types for formateData and formatNumber

### DIFF
--- a/packages/lib/formulas/formatDate/formula.json
+++ b/packages/lib/formulas/formatDate/formula.json
@@ -10,7 +10,7 @@
     {
       "name": "Locale(s)",
       "description": "Optional locale to use for formatting the Date, e.g. \"en\" or \"fr\". Multiple locales can be provided (as an Array of Strings) to provide a fallback locale. The default value is the runtime's locale.",
-      "type": { "type": "String | Array" },
+      "type": { "type": "String or Array" },
       "formula": { "type": "value", "value": null }
     },
     {

--- a/packages/lib/formulas/formatNumber/formula.json
+++ b/packages/lib/formulas/formatNumber/formula.json
@@ -10,7 +10,7 @@
     {
       "name": "Locale(s)",
       "description": "Optional locale to use for formatting the Number, e.g. \"en\" or \"fr\". Multiple locales can be provided (as an Array of Strings) to provide a fallback locale. The default value is the runtime's locale.",
-      "type": { "type": "String | Array" },
+      "type": { "type": "String or Array" },
       "formula": { "type": "value", "value": null }
     },
     {


### PR DESCRIPTION
This fixes a markdown parsing issue.