### PR TITLE
Tell Google to not crawl links in serialized JSON

### DIFF
--- a/packages/backend/src/routes/nordcraftPage.ts
+++ b/packages/backend/src/routes/nordcraftPage.ts
@@ -159,7 +159,10 @@ export const nordcraftPage = async ({
     html`<!doctype html>
       <html lang="${language}">
         <head>
-          ${raw(head)} ${raw(codeImport)}
+          ${raw(head)}
+          <!--googleoff: all-->
+          ${raw(codeImport)}
+          <!--googleon: all-->
         </head>
         <body>
           <div id="App">${raw(body)}</div>


### PR DESCRIPTION
If the serialized JSON structure for a page included links, Google would sometimes try to crawl them. This should stop Google from crawling them - see https://www.google.com/support/enterprise/static/gsa/docs/admin/current/gsa_doc_set/admin_crawl/preparing.html#1076243