### PR TITLE
Add new action for setting an Http-Only cookie

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
         "@html-eslint/eslint-plugin": "^0.40.3",
         "@html-eslint/parser": "^0.40.0",
         "@octokit/core": "6.1.5",
+        "@types/bun": "1.2.13",
         "@types/jest": "29.5.14",
         "@typescript-eslint/eslint-plugin": "8.32.1",
         "@typescript-eslint/parser": "8.32.1",
@@ -382,6 +383,8 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.20.6", "", { "dependencies": { "@babel/types": "^7.20.7" } }, "sha512-r1bzfrm0tomOI8g1SzvCaQHo6Lcv6zu0EA+W2kHrt8dyrHQxGzBBL4kdkzIS+jBMV+EYcMAEAqXqYaLJq5rOZg=="],
 
+    "@types/bun": ["@types/bun@1.2.13", "", { "dependencies": { "bun-types": "1.2.13" } }, "sha512-u6vXep/i9VBxoJl3GjZsl/BFIsvML8DfVDO0RYLEwtSZSp981kEO1V5NwRcO1CPJ7AmvpbnDCiMKo3JvbDEjAg=="],
+
     "@types/estree": ["@types/estree@1.0.6", "", {}, "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="],
 
     "@types/graceful-fs": ["@types/graceful-fs@4.1.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ=="],
@@ -467,6 +470,8 @@
     "bser": ["bser@2.1.1", "", { "dependencies": { "node-int64": "^0.4.0" } }, "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
+    "bun-types": ["bun-types@1.2.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-rRjA1T6n7wto4gxhAO/ErZEtOXyEZEmnIHQfl0Dt1QQSB4QV0iP6BZ9/YB5fZaHFQ2dwHFrmPaRQ9GGMX01k9Q=="],
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@html-eslint/eslint-plugin": "^0.40.3",
     "@html-eslint/parser": "^0.40.0",
     "@octokit/core": "6.1.5",
+    "@types/bun": "1.2.13",
     "@types/jest": "29.5.14",
     "@typescript-eslint/eslint-plugin": "8.32.1",
     "@typescript-eslint/parser": "8.32.1",

--- a/packages/lib/actions/setHttpOnlyCookie/action.json
+++ b/packages/lib/actions/setHttpOnlyCookie/action.json
@@ -1,0 +1,61 @@
+{
+  "name": "Set Http-Only Cookie",
+  "description": "Save a key/value pair as an Http-Only cookie. Useful for storing JWTs or other tokens.",
+  "arguments": [
+    {
+      "name": "Name",
+      "description": "The name of the cookie.",
+      "type": { "type": "String" },
+      "formula": {
+        "type": "value",
+        "value": "access_token"
+      }
+    },
+    {
+      "name": "Value",
+      "description": "The value to be stored in the cookie.",
+      "type": { "type": "String" },
+      "formula": {
+        "type": "value",
+        "value": ""
+      }
+    },
+    {
+      "name": "Expires in",
+      "description": "(Optional) Time in seconds until the cookie expires. Defaults to 3600 (1 hour). This should be left blank for JWTs.",
+      "type": { "type": "Number" },
+      "formula": {
+        "type": "value",
+        "value": ""
+      }
+    },
+    {
+      "name": "SameSite",
+      "description": "(Optional) The SameSite attribute of the cookie. Defaults to Lax.",
+      "type": { "type": "String" },
+      "formula": {
+        "type": "value",
+        "value": ""
+      }
+    },
+    {
+      "name": "Path",
+      "description": "(Optional) The Path attribute of the cookie. Defaults to /.",
+      "type": { "type": "String" },
+      "formula": {
+        "type": "value",
+        "value": ""
+      }
+    }
+  ],
+  "events": {
+    "Success": {
+      "description": "This event is triggered once the cookie has been saved.",
+      "actions": []
+    },
+    "Error": {
+      "description": "This event is triggered if the cookie could not be saved.",
+      "actions": []
+    }
+  }
+}

--- a/packages/lib/actions/setHttpOnlyCookie/handler.test.ts
+++ b/packages/lib/actions/setHttpOnlyCookie/handler.test.ts
@@ -1,0 +1,153 @@
+import {
+  afterAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  spyOn,
+} from 'bun:test'
+import handler from './handler'
+
+const spyFetch = spyOn(globalThis, 'fetch')
+
+describe('set http only cookie', async () => {
+  beforeEach(() => {
+    spyFetch.mockReset()
+  })
+  it('should set a cookie', async () => {
+    const mockGetExample = async (url: string) => {
+      expect(url).toBe(
+        '/.toddle/cookies/set-session-cookie?name=my_cookie&value=my_value&sameSite=Lax&path=%2F&ttl=3600',
+      )
+      return new Response(`{"success":true}`)
+    }
+    spyFetch.mockImplementation(mockGetExample as any)
+
+    const triggerActionEvent = mock((trigger: string, event: any) => {
+      expect(trigger).toBe('Success')
+      expect(event).toBe(undefined)
+    })
+    expect(
+      () =>
+        handler(['my_cookie', 'my_value', 3600, 'Lax', '/'], {
+          triggerActionEvent,
+        } as any) as any,
+    ).not.toThrow()
+    expect(triggerActionEvent).toHaveBeenCalled()
+  })
+  it('should handle network errors', async () => {
+    const mockFailedExample = async () => {
+      return new Response('This operation is not permitted', { status: 403 })
+    }
+    spyFetch.mockImplementation(mockFailedExample as any)
+
+    const triggerActionEvent = mock((trigger: string, event: any) => {
+      expect(trigger).toBe('Error')
+      expect(event).toBeInstanceOf(Error)
+      expect((event as Error).message).toBe('This operation is not permitted')
+    })
+    expect(
+      () =>
+        handler(['my_cookie', 'my_value', 3600, 'Lax', '/'], {
+          triggerActionEvent,
+        } as any) as any,
+    ).not.toThrow()
+    expect(triggerActionEvent).toHaveBeenCalled()
+  })
+  it('should fail for invalid values', async () => {
+    const triggerActionEvent = mock((trigger: string, event: any) => {
+      expect(trigger).toBe('Error')
+      expect(event).toBeInstanceOf(Error)
+      expect((event as Error).message).toBe(
+        'The "Value" argument must be a string',
+      )
+    })
+    expect(
+      () =>
+        handler(['my_cookie', { test: 'value' }, 3600, 'Lax', '/'], {
+          triggerActionEvent,
+        } as any) as any,
+    ).not.toThrow()
+    expect(
+      () =>
+        handler(['my_cookie', undefined, 3600, 'Lax', '/'], {
+          triggerActionEvent,
+        } as any) as any,
+    ).not.toThrow()
+    expect(triggerActionEvent).toHaveBeenCalledTimes(2)
+  })
+  it('should fail for invalid names', async () => {
+    const triggerActionEvent = mock((trigger: string, event: any) => {
+      expect(trigger).toBe('Error')
+      expect(event).toBeInstanceOf(Error)
+      expect((event as Error).message).toBe(
+        'The "Name" argument must be a string',
+      )
+    })
+    expect(
+      () =>
+        handler([42, 'value', 3600, 'Lax', '/'], {
+          triggerActionEvent,
+        } as any) as any,
+    ).not.toThrow()
+    expect(
+      () =>
+        handler([undefined, 'value', 3600, 'Lax', '/'], {
+          triggerActionEvent,
+        } as any) as any,
+    ).not.toThrow()
+    expect(triggerActionEvent).toHaveBeenCalledTimes(2)
+  })
+  it('should fail for invalid ttl', async () => {
+    const triggerActionEvent = mock((trigger: string, event: any) => {
+      expect(trigger).toBe('Error')
+      expect(event).toBeInstanceOf(Error)
+      expect((event as Error).message).toBe(
+        'The "Expires in" argument must be a number',
+      )
+    })
+    expect(
+      () =>
+        handler(['my_cookie', 'value', '3600', 'Lax', '/'], {
+          triggerActionEvent,
+        } as any) as any,
+    ).not.toThrow()
+    expect(triggerActionEvent).toHaveBeenCalled()
+  })
+  it('should fail for invalid SameSite', async () => {
+    const triggerActionEvent = mock((trigger: string, event: any) => {
+      expect(trigger).toBe('Error')
+      expect(event).toBeInstanceOf(Error)
+      expect((event as Error).message).toBe(
+        'The "SameSite" argument must be "Lax", "Strict" or "None"',
+      )
+    })
+    expect(
+      () =>
+        handler(['my_cookie', 'value', '3600', 'Invalid', '/'], {
+          triggerActionEvent,
+        } as any) as any,
+    ).not.toThrow()
+    expect(triggerActionEvent).toHaveBeenCalled()
+  })
+  it('should fail for invalid Path', async () => {
+    const triggerActionEvent = mock((trigger: string, event: any) => {
+      expect(trigger).toBe('Error')
+      expect(event).toBeInstanceOf(Error)
+      expect((event as Error).message).toBe(
+        'The "Path" argument must be a string and start with /',
+      )
+    })
+    expect(
+      () =>
+        handler(['my_cookie', 'value', '3600', 'Lax', 'invalid'], {
+          triggerActionEvent,
+        } as any) as any,
+    ).not.toThrow()
+    expect(triggerActionEvent).toHaveBeenCalled()
+  })
+  afterAll(() => {
+    spyFetch.mockRestore()
+  })
+})

--- a/packages/lib/actions/setHttpOnlyCookie/handler.ts
+++ b/packages/lib/actions/setHttpOnlyCookie/handler.ts
@@ -1,0 +1,71 @@
+import type { ActionHandler } from '@nordcraft/core/dist/types'
+
+const handler: ActionHandler = async function (
+  [name, value, ttl, sameSite = 'Lax', path = '/'],
+  ctx,
+) {
+  if (typeof name !== 'string') {
+    ctx.triggerActionEvent(
+      'Error',
+      new Error('The "Name" argument must be a string'),
+    )
+    return
+  }
+  if (typeof value !== 'string') {
+    ctx.triggerActionEvent(
+      'Error',
+      new Error('The "Value" argument must be a string'),
+    )
+    return
+  }
+  if (
+    typeof sameSite !== 'string' ||
+    !['lax', 'strict', 'none'].includes(sameSite.toLocaleLowerCase())
+  ) {
+    ctx.triggerActionEvent(
+      'Error',
+      new Error('The "SameSite" argument must be "Lax", "Strict" or "None"'),
+    )
+    return
+  }
+  if (typeof path !== 'string' || !path.startsWith('/')) {
+    ctx.triggerActionEvent(
+      'Error',
+      new Error('The "Path" argument must be a string and start with /'),
+    )
+    return
+  }
+  if (
+    ttl !== undefined &&
+    ttl !== null &&
+    (typeof ttl !== 'number' || isNaN(ttl))
+  ) {
+    ctx.triggerActionEvent(
+      'Error',
+      new Error('The "Expires in" argument must be a number'),
+    )
+    return
+  }
+  const params = new URLSearchParams()
+  params.set('name', name)
+  params.set('value', value)
+  params.set('sameSite', sameSite)
+  params.set('path', path)
+  if (typeof ttl === 'number') {
+    params.set('ttl', String(ttl))
+  }
+  try {
+    const res = await fetch(
+      `/.toddle/cookies/set-session-cookie?${params.toString()}`,
+    )
+    if (res.ok) {
+      ctx.triggerActionEvent('Success', undefined)
+    } else {
+      ctx.triggerActionEvent('Error', new Error(await res.text()))
+    }
+  } catch (error) {
+    ctx.triggerActionEvent('Error', error)
+  }
+}
+
+export default handler

--- a/packages/lib/tsconfig.json
+++ b/packages/lib/tsconfig.json
@@ -11,7 +11,7 @@
     "strict": true,
     "strictBuiltinIteratorReturn": true,
     "target": "ESNext",
-    "types": []
+    "types": ["bun-types"]
   },
   "include": ["actions", "formulas", "./actions.ts", "./formulas.ts"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
This adds a more advanced version of the existing `Set session cookies` action, which allows overriding more cookie settings, including:

- The cookie's name
- The cookie's value (obviously)
- The cookie's path
- The cookie's SameSite attribute
- The cookie's ttl

It also has better error handling/input validation.

**TODO:**

- [ ] Make the existing `Set session cookies` deprecated with our issue rule
- [ ] Update endpoint to support new parameters
      