### PR TITLE
Allow configuring credentials for API requests

### DIFF
--- a/packages/core/src/api/apiTypes.ts
+++ b/packages/core/src/api/apiTypes.ts
@@ -95,6 +95,8 @@ export interface ApiRequest extends ApiBase {
     // auto: The response will be handled based on the content type of the response
     // stream: The response will be handled as a stream
     parserMode: ApiParserMode
+    // Whether to include credentials (cookies) in the request or not. Default is 'same-origin'
+    credentials?: 'include' | 'same-origin' | 'omit'
   }
   // Shared logic for client/server 👇
   // The user could distinguish using an environment

--- a/packages/runtime/src/api/createAPIv2.ts
+++ b/packages/runtime/src/api/createAPIv2.ts
@@ -47,7 +47,9 @@ export function createAPI(
   let timer: any = null
   let api = { ...apiRequest }
 
-  function constructRequest(api: ApiRequest) {
+  function constructRequest(
+    api: ApiRequest,
+  ): ReturnType<typeof createApiRequest> {
     // Get baseUrl and validate it. (It wont be in web component context)
     let baseUrl: string | undefined = window.origin
     try {
@@ -56,12 +58,26 @@ export function createAPI(
       baseUrl = undefined
     }
 
-    return createApiRequest({
+    const request = createApiRequest({
       api,
       formulaContext: getFormulaContext(api),
       baseUrl,
       defaultHeaders: undefined,
     })
+    return {
+      ...request,
+      requestSettings: {
+        ...request.requestSettings,
+        // credentials is a browser specific setting and cannot be set in the
+        // createApiRequest function directly as it's shared between server and client
+        credentials:
+          api.client?.credentials &&
+          ['include', 'same-origin', 'omit'].includes(api.client.credentials)
+            ? api.client.credentials
+            : // Default to same-origin
+              undefined,
+      },
+    }
   }
 
   // Create the formula context for the api


### PR DESCRIPTION
In some (advanced) use cases, it may be useful to include cookies in cross-site requests - for instance when/if you authenticate directly with the API on a subdomain or on a path you control.
The default will be 'same-origin' to keep the default behavior of the browser (fetch).

When this change is live, we will add a `Select` in the advanced part of the API panel for configuring this setting.

Please see the feature request here https://discord.com/channels/972416966683926538/1373564360122961920/1373942677367689247