### PR TITLE
Add support for hash param in route declarations

### DIFF
--- a/packages/core/src/api/api.test.ts
+++ b/packages/core/src/api/api.test.ts
@@ -160,27 +160,50 @@ describe('getUrl()', () => {
     )
     expect(url.href).toBe('https://mysite.com/test/path/hello/world')
   })
-})
-test('supports query parameters in url declaration', () => {
-  const url = getUrl(
-    {
-      url: valueFormula('/test/path/?q=test&hello=world'),
-      path: {
-        a: { formula: valueFormula('hello'), index: 0 },
-        b: { formula: valueFormula('world'), index: 1 },
-      },
-      queryParams: {
-        search: {
-          formula: valueFormula('test'),
+  test('supports query parameters in url declaration', () => {
+    const url = getUrl(
+      {
+        url: valueFormula('/test/path/?q=test&hello=world'),
+        path: {
+          a: { formula: valueFormula('hello'), index: 0 },
+          b: { formula: valueFormula('world'), index: 1 },
+        },
+        queryParams: {
+          search: {
+            formula: valueFormula('test'),
+          },
         },
       },
-    },
-    undefined as any,
-    'https://mysite.com',
-  )
-  expect(url.href).toBe(
-    'https://mysite.com/test/path/hello/world?q=test&hello=world&search=test',
-  )
+      undefined as any,
+      'https://mysite.com',
+    )
+    expect(url.href).toBe(
+      'https://mysite.com/test/path/hello/world?q=test&hello=world&search=test',
+    )
+  })
+  test('supports hash parameter', () => {
+    const url = getUrl(
+      {
+        url: valueFormula('https://mysite.com/test/path/?q=test&hello=world'),
+        path: {
+          a: { formula: valueFormula('hello'), index: 0 },
+          b: { formula: valueFormula('world'), index: 1 },
+        },
+        queryParams: {
+          search: {
+            formula: valueFormula('test'),
+          },
+        },
+        hash: { formula: valueFormula('my-hash') },
+      },
+      undefined as any,
+      'https://mysite.com',
+    )
+    expect(url.hash).toBe('#my-hash')
+    expect(url.href).toBe(
+      'https://mysite.com/test/path/hello/world?q=test&hello=world&search=test#my-hash',
+    )
+  })
 })
 describe('getApiHeaders()', () => {
   test('it returns valid headers', () => {

--- a/packages/core/src/api/api.ts
+++ b/packages/core/src/api/api.ts
@@ -72,13 +72,17 @@ export const getUrl = (
   ])
   const queryString =
     [...queryParams.entries()].length > 0 ? `?${queryParams.toString()}` : ''
+  const hash = applyFormula(api.hash?.formula, formulaContext)
+  const hashString =
+    typeof hash === 'string' && hash.length > 0 ? `#${hash}` : ''
   if (parsedUrl) {
     const combinedUrl = new URL(parsedUrl.origin, baseUrl)
     combinedUrl.pathname = path
     combinedUrl.search = queryParams.toString()
+    combinedUrl.hash = hashString
     return combinedUrl
   } else {
-    return new URL(`${path}${queryString}`, baseUrl)
+    return new URL(`${path}${queryString}${hashString}`, baseUrl)
   }
 }
 

--- a/packages/core/src/api/apiTypes.ts
+++ b/packages/core/src/api/apiTypes.ts
@@ -60,6 +60,8 @@ export interface ApiBase extends NordcraftMetadata {
     // The enabled formula is used to determine if the query parameter should be included in the request or not
     { formula: Formula; enabled?: Formula | null }
   >
+  // hash is relevant for redirects and rewrites, but not for API calls
+  hash?: { formula: Formula } | null
 }
 
 export interface ApiRequest extends ApiBase {


### PR DESCRIPTION
To allow redirecting to a URL including a hash parameter, we must evaluate a hash formula when we evaluate the URL of an API request. Technically, API requests will never have a hash, but it's not much overhead and it's useful to reuse the same logic for both API and redirect/rewrites.
I'm not sure the hash parameter adds a lot of value for a rewrite since we would always grab the HTML page as a server, but it does not hurt to support it.