### PR TITLE
Use up-to-date componentData for API events

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nordcraft",
   "type": "module",
   "license": "Apache-2.0",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "homepage": "https://github.com/nordcraftengine/nordcraft",
   "private": "false",
   "workspaces": [

--- a/packages/runtime/src/api/createAPIv2.ts
+++ b/packages/runtime/src/api/createAPIv2.ts
@@ -110,8 +110,8 @@ export function createAPI({
     }, {})
 
     const data = {
-      ...formulaContext.data,
       ...componentData,
+      ...formulaContext.data,
       ApiInputs: {
         ...evaluatedInputs,
       },


### PR DESCRIPTION
Fixes an issue in [1.0.15](https://github.com/nordcraftengine/nordcraft/releases/tag/1.0.15) where variables would not be available for API events.
The original `componentData` provided during API creation/execution would be out of sync for variables for instance. Hence, we should prefer the latest `componentData` from the data signal when we create our formula context - which is used for the `componentData` for API events.