### PR TITLE
Use up-to-date context for all API event actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nordcraft",
   "type": "module",
   "license": "Apache-2.0",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "homepage": "https://github.com/nordcraftengine/nordcraft",
   "private": "false",
   "workspaces": [

--- a/packages/runtime/src/api/createAPIv2.ts
+++ b/packages/runtime/src/api/createAPIv2.ts
@@ -179,7 +179,6 @@ export function createAPI({
     }
     componentData: ComponentData
   }) {
-    const formulaContext = getFormulaContext(api, componentData)
     switch (eventName) {
       case 'message': {
         const event = createApiEvent('message', data.body)
@@ -187,7 +186,7 @@ export function createAPI({
           handleAction(
             action,
             {
-              ...formulaContext.data,
+              ...getFormulaContext(api, componentData).data,
               Event: event,
             },
             ctx,
@@ -202,7 +201,7 @@ export function createAPI({
           handleAction(
             action,
             {
-              ...formulaContext.data,
+              ...getFormulaContext(api, componentData).data,
               Event: event,
             },
             ctx,
@@ -220,7 +219,7 @@ export function createAPI({
           handleAction(
             action,
             {
-              ...formulaContext.data,
+              ...getFormulaContext(api, componentData).data,
               Event: event,
             },
             ctx,


### PR DESCRIPTION
The `formulaContext` was only evaluated once, and not after for each action. This meant that changes to the context after the first evaluation were not reflected in subsequent actions.

Please test on this page (locally): https://componentdata-awesome_blog.toddle.site/componentdata - see the logic here https://editor.nordcraft.com/projects/awesome_blog/branches/componentdata/components/componentdata?canvas-width=800&canvas-height=800&selection=apis.Weather%2520API.client.onCompleted&rightpanel=style and verify:
- Repeat items are available in API events
- Workflow parameters are available in API events
- Changes to variables in API events are persisted for subsequent events