### PR TITLE
Allow template values in body of proxied requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,3 +106,18 @@ jobs:
         run: |
           cd packages/search
           bun test
+  test-backend:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout backend
+        uses: actions/checkout@v4
+      - name: Install bun
+        uses: oven-sh/setup-bun@v1
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Build
+        run: bun run build
+      - name: Test backend
+        run: |
+          cd packages/backend
+          bun test

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nordcraft",
   "type": "module",
   "license": "Apache-2.0",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "homepage": "https://github.com/nordcraftengine/nordcraft",
   "private": "false",
   "workspaces": [

--- a/packages/backend/src/routes/apiProxy.test.ts
+++ b/packages/backend/src/routes/apiProxy.test.ts
@@ -78,9 +78,8 @@ describe('API proxy', () => {
         targetUrl.searchParams.get('param2'),
       )
       expect(req.method).toBe('POST')
-      console.log('Incoming request', req)
       const body = await req.text()
-      expect(body).toBe('hello world') // The body should not be modified
+      expect(body).toBe('{"myToken":"my_refresh_token"}') // The body should not be modified
       // The PROXY_URL_HEADER should be removed from the request headers
       expect(req.headers.get(PROXY_URL_HEADER)).toBeNull()
       return new Response(`{"success":true}`)
@@ -95,11 +94,14 @@ describe('API proxy', () => {
           componentName: 'MyComponent',
           apiName: 'MyApi',
         },
-        // body: { test: 'hello' },
-      } as any,
+      },
       {
-        headers: { [PROXY_URL_HEADER]: targetUrl.href },
-        body: { test: 'hello' },
+        headers: {
+          [PROXY_URL_HEADER]: targetUrl.href,
+          Cookies: 'refresh_token=my_refresh_token',
+        },
+        body: { myToken: STRING_TEMPLATE('cookies', 'refresh_token') },
+        // type casting is needed because Hono's test client doesn't currently support a body in its types
       } as any,
     )
     expect(res.status).toBe(200)

--- a/packages/backend/src/routes/apiProxy.test.ts
+++ b/packages/backend/src/routes/apiProxy.test.ts
@@ -36,6 +36,7 @@ describe('API proxy', () => {
       )
       // The PROXY_URL_HEADER should be removed from the request headers
       expect(req.headers.get(PROXY_URL_HEADER)).toBeNull()
+      expect(req.headers.get(PROXY_TEMPLATES_IN_BODY)).toBeNull()
       expect(req.headers.get('Authorization')).toBe(`Bearer my_value`)
       return new Response(`{"success":true}`)
     }
@@ -80,6 +81,7 @@ describe('API proxy', () => {
       expect(body).toEqual({ myToken: 'my_refresh_token' }) // The body should have been updated with the template value
       // The PROXY_URL_HEADER should be removed from the request headers
       expect(req.headers.get(PROXY_URL_HEADER)).toBeNull()
+      expect(req.headers.get(PROXY_TEMPLATES_IN_BODY)).toBeNull()
       return new Response(`{"success":true}`, { status: 200 })
     }
 
@@ -134,6 +136,7 @@ describe('API proxy', () => {
       })
       // The PROXY_URL_HEADER should be removed from the request headers
       expect(req.headers.get(PROXY_URL_HEADER)).toBeNull()
+      expect(req.headers.get(PROXY_TEMPLATES_IN_BODY)).toBeNull()
       return new Response(`{"success":true}`, { status: 200 })
     }
 

--- a/packages/backend/src/routes/apiProxy.test.ts
+++ b/packages/backend/src/routes/apiProxy.test.ts
@@ -111,7 +111,7 @@ describe('API proxy', () => {
     )
     expect(res.status).toBe(200)
   })
-  it("Should ignore the request's body if the special", async () => {
+  it("Should proxy the request's body untouched if the special header is not set", async () => {
     // Create the test client from the app instance
     const client = testClient(
       new Hono().post(

--- a/packages/backend/src/routes/apiProxy.test.ts
+++ b/packages/backend/src/routes/apiProxy.test.ts
@@ -1,0 +1,110 @@
+import { STRING_TEMPLATE } from '@nordcraft/core/dist/api/template'
+import { PROXY_URL_HEADER } from '@nordcraft/core/dist/utils/url'
+import { afterAll, beforeEach, describe, expect, it, spyOn } from 'bun:test'
+import { Hono } from 'hono'
+import { testClient } from 'hono/testing'
+import { proxyRequestHandler } from './apiProxy'
+
+const spyFetch = spyOn(globalThis, 'fetch')
+
+describe('API proxy', () => {
+  beforeEach(() => {
+    spyFetch.mockReset()
+  })
+  it('Should proxy a request to the correct url', async () => {
+    // Create the test client from the app instance
+    const client = testClient(
+      new Hono().get(
+        '.toddle/omvej/components/:componentName/apis/:apiName',
+        proxyRequestHandler,
+      ),
+    )
+    const targetUrl = new URL(
+      'https://example.com/api?param1=value1&param2=value2',
+    )
+    const mockGetExample = async (req: Request) => {
+      const url = new URL(req.url)
+      expect(url.pathname).toBe(targetUrl.pathname)
+      expect(url.searchParams.get('param1')).toBe(
+        targetUrl.searchParams.get('param1'),
+      )
+      expect(url.searchParams.get('param2')).toBe(
+        targetUrl.searchParams.get('param2'),
+      )
+      // The PROXY_URL_HEADER should be removed from the request headers
+      expect(req.headers.get(PROXY_URL_HEADER)).toBeNull()
+      expect(req.headers.get('Authorization')).toBe(`Bearer my_value`)
+      return new Response(`{"success":true}`)
+    }
+
+    spyFetch.mockImplementation(mockGetExample as any)
+    const res = await client['.toddle'].omvej.components[':componentName'].apis[
+      ':apiName'
+    ].$get(
+      {
+        param: {
+          componentName: 'MyComponent',
+          apiName: 'MyApi',
+        },
+      },
+      {
+        headers: {
+          [PROXY_URL_HEADER]: targetUrl.href,
+          Authorization: `Bearer ${STRING_TEMPLATE('cookies', 'my_cookie')}`,
+          Cookie: `my_cookie=my_value; other_cookie=other_value`,
+        },
+      },
+    )
+    expect(res.status).toBe(200)
+  })
+  it('Should replace the request body with template values', async () => {
+    // Create the test client from the app instance
+    const client = testClient(
+      new Hono().post(
+        '.toddle/omvej/components/:componentName/apis/:apiName',
+        proxyRequestHandler,
+      ),
+    )
+    const targetUrl = new URL(
+      'https://example.com/api?param1=value1&param2=value2',
+    )
+    const mockPostExample = async (req: Request) => {
+      const url = new URL(req.url)
+      expect(url.pathname).toBe(targetUrl.pathname)
+      expect(url.searchParams.get('param1')).toBe(
+        targetUrl.searchParams.get('param1'),
+      )
+      expect(url.searchParams.get('param2')).toBe(
+        targetUrl.searchParams.get('param2'),
+      )
+      expect(req.method).toBe('POST')
+      console.log('Incoming request', req)
+      const body = await req.text()
+      expect(body).toBe('hello world') // The body should not be modified
+      // The PROXY_URL_HEADER should be removed from the request headers
+      expect(req.headers.get(PROXY_URL_HEADER)).toBeNull()
+      return new Response(`{"success":true}`)
+    }
+
+    spyFetch.mockImplementation(mockPostExample as any)
+    const res = await client['.toddle'].omvej.components[':componentName'].apis[
+      ':apiName'
+    ].$post(
+      {
+        param: {
+          componentName: 'MyComponent',
+          apiName: 'MyApi',
+        },
+        // body: { test: 'hello' },
+      } as any,
+      {
+        headers: { [PROXY_URL_HEADER]: targetUrl.href },
+        body: { test: 'hello' },
+      } as any,
+    )
+    expect(res.status).toBe(200)
+  })
+  afterAll(() => {
+    spyFetch.mockRestore()
+  })
+})

--- a/packages/backend/src/routes/apiProxy.test.ts
+++ b/packages/backend/src/routes/apiProxy.test.ts
@@ -1,5 +1,8 @@
 import { STRING_TEMPLATE } from '@nordcraft/core/dist/api/template'
-import { PROXY_URL_HEADER } from '@nordcraft/core/dist/utils/url'
+import {
+  PROXY_TEMPLATES_IN_BODY,
+  PROXY_URL_HEADER,
+} from '@nordcraft/core/dist/utils/url'
 import { afterAll, beforeEach, describe, expect, it, spyOn } from 'bun:test'
 import { Hono } from 'hono'
 import { testClient } from 'hono/testing'
@@ -65,30 +68,25 @@ describe('API proxy', () => {
         proxyRequestHandler,
       ),
     )
-    const targetUrl = new URL(
-      'https://example.com/api?param1=value1&param2=value2',
-    )
+    const targetUrl = new URL('https://example.com/api')
+
+    // The mockPostExample represents the target server's response
+    // This means that it's not the proxy server's fetch call, but the destination server's fetch call
     const mockPostExample = async (req: Request) => {
       const url = new URL(req.url)
       expect(url.pathname).toBe(targetUrl.pathname)
-      expect(url.searchParams.get('param1')).toBe(
-        targetUrl.searchParams.get('param1'),
-      )
-      expect(url.searchParams.get('param2')).toBe(
-        targetUrl.searchParams.get('param2'),
-      )
       expect(req.method).toBe('POST')
-      const body = await req.text()
-      expect(body).toBe('{"myToken":"my_refresh_token"}') // The body should not be modified
+      const body = await req.json()
+      expect(body).toEqual({ myToken: 'my_refresh_token' }) // The body should have been updated with the template value
       // The PROXY_URL_HEADER should be removed from the request headers
       expect(req.headers.get(PROXY_URL_HEADER)).toBeNull()
-      return new Response(`{"success":true}`)
+      return new Response(`{"success":true}`, { status: 200 })
     }
 
     spyFetch.mockImplementation(mockPostExample as any)
-    const res = await client['.toddle'].omvej.components[':componentName'].apis[
-      ':apiName'
-    ].$post(
+    const res = await client['.toddle']['omvej']['components'][
+      ':componentName'
+    ]['apis'][':apiName'].$post(
       {
         param: {
           componentName: 'MyComponent',
@@ -97,12 +95,71 @@ describe('API proxy', () => {
       },
       {
         headers: {
+          // The destination url
           [PROXY_URL_HEADER]: targetUrl.href,
-          Cookies: 'refresh_token=my_refresh_token',
+          // Indicates that the body should be read and template values applied
+          [PROXY_TEMPLATES_IN_BODY]: 'true',
+          Cookie: 'refresh_token=my_refresh_token; Path=/; HttpOnly',
+          ['Content-Type']: 'application/json',
         },
-        body: { myToken: STRING_TEMPLATE('cookies', 'refresh_token') },
-        // type casting is needed because Hono's test client doesn't currently support a body in its types
-      } as any,
+        init: {
+          body: JSON.stringify({
+            myToken: STRING_TEMPLATE('cookies', 'refresh_token'),
+          }),
+        },
+      },
+    )
+    expect(res.status).toBe(200)
+  })
+  it("Should ignore the request's body if the special", async () => {
+    // Create the test client from the app instance
+    const client = testClient(
+      new Hono().post(
+        '.toddle/omvej/components/:componentName/apis/:apiName',
+        proxyRequestHandler,
+      ),
+    )
+    const targetUrl = new URL('https://example.com/api')
+
+    // The mockPostExample represents the target server's response
+    // This means that it's not the proxy server's fetch call, but the destination server's fetch call
+    const mockPostExample = async (req: Request) => {
+      const url = new URL(req.url)
+      expect(url.pathname).toBe(targetUrl.pathname)
+      expect(req.method).toBe('POST')
+      const body = await req.json()
+      // The body should not have been touched/updated by the proxy
+      expect(body).toEqual({
+        myToken: STRING_TEMPLATE('cookies', 'refresh_token'),
+      })
+      // The PROXY_URL_HEADER should be removed from the request headers
+      expect(req.headers.get(PROXY_URL_HEADER)).toBeNull()
+      return new Response(`{"success":true}`, { status: 200 })
+    }
+
+    spyFetch.mockImplementation(mockPostExample as any)
+    const res = await client['.toddle']['omvej']['components'][
+      ':componentName'
+    ]['apis'][':apiName'].$post(
+      {
+        param: {
+          componentName: 'MyComponent',
+          apiName: 'MyApi',
+        },
+      },
+      {
+        headers: {
+          // The destination url
+          [PROXY_URL_HEADER]: targetUrl.href,
+          Cookie: 'refresh_token=my_refresh_token; Path=/; HttpOnly',
+          ['Content-Type']: 'application/json',
+        },
+        init: {
+          body: JSON.stringify({
+            myToken: STRING_TEMPLATE('cookies', 'refresh_token'),
+          }),
+        },
+      },
     )
     expect(res.status).toBe(200)
   })

--- a/packages/backend/src/routes/apiProxy.ts
+++ b/packages/backend/src/routes/apiProxy.ts
@@ -63,8 +63,8 @@ export const proxyRequestHandler = async (
       HttpMethodsWithAllowedBody.includes(req.method as ApiMethod) &&
       req.headers.get(PROXY_TEMPLATES_IN_BODY) !== null
     ) {
-      // If the request has the PROXY_TEMPLATES_IN_BODY header set to true,
-      // we need to apply the template values to the body as well
+      // If the request has the PROXY_TEMPLATES_IN_BODY header set,
+      // we must apply the template values to the body as well
       try {
         const bodyText = await req.text()
         templateBody = applyTemplateValues(bodyText, requestCookies)

--- a/packages/backend/src/routes/apiProxy.ts
+++ b/packages/backend/src/routes/apiProxy.ts
@@ -1,5 +1,13 @@
-import { NON_BODY_RESPONSE_CODES } from '@nordcraft/core/dist/api/api'
-import { PROXY_URL_HEADER, validateUrl } from '@nordcraft/core/dist/utils/url'
+import {
+  HttpMethodsWithAllowedBody,
+  NON_BODY_RESPONSE_CODES,
+} from '@nordcraft/core/dist/api/api'
+import type { ApiMethod } from '@nordcraft/core/dist/api/apiTypes'
+import {
+  PROXY_TEMPLATES_IN_BODY,
+  PROXY_URL_HEADER,
+  validateUrl,
+} from '@nordcraft/core/dist/utils/url'
 import { getRequestCookies } from '@nordcraft/ssr/dist/rendering/cookies'
 import {
   applyTemplateValues,
@@ -50,12 +58,34 @@ export const proxyRequestHandler = async (
     )
   }
   try {
+    let templateBody: string | undefined
+    if (
+      HttpMethodsWithAllowedBody.includes(req.method as ApiMethod) &&
+      req.headers.get(PROXY_TEMPLATES_IN_BODY) === 'true'
+    ) {
+      // If the request has the PROXY_TEMPLATES_IN_BODY header set to true,
+      // we need to apply the template values to the body as well
+      try {
+        const bodyText = await req.text()
+        templateBody = applyTemplateValues(bodyText, requestCookies)
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.error('Error applying template values to request body', e)
+        return c.json(
+          {
+            error:
+              'Error applying template values to request body. Perhaps the request body was not text?',
+          },
+          { status: 400 },
+        )
+      }
+    }
     const request = new Request(outgoingRequestUrl.href, {
       // We copy over the method
       method: c.req.method,
       headers,
-      // We forward the body
-      body: req.body,
+      // We use the adjusted body or forward the body as is
+      body: templateBody ?? req.body,
       // Let's add a 5s timeout
       signal: AbortSignal.timeout(5000),
     })

--- a/packages/backend/src/routes/apiProxy.ts
+++ b/packages/backend/src/routes/apiProxy.ts
@@ -61,7 +61,7 @@ export const proxyRequestHandler = async (
     let templateBody: string | undefined
     if (
       HttpMethodsWithAllowedBody.includes(req.method as ApiMethod) &&
-      req.headers.get(PROXY_TEMPLATES_IN_BODY) === 'true'
+      req.headers.get(PROXY_TEMPLATES_IN_BODY) !== null
     ) {
       // If the request has the PROXY_TEMPLATES_IN_BODY header set to true,
       // we need to apply the template values to the body as well

--- a/packages/core/src/api/api.ts
+++ b/packages/core/src/api/api.ts
@@ -82,7 +82,7 @@ export const getUrl = (
   }
 }
 
-const HttpMethodsWithAllowedBody: ApiMethod[] = [
+export const HttpMethodsWithAllowedBody: ApiMethod[] = [
   ApiMethod.POST,
   ApiMethod.DELETE,
   ApiMethod.PUT,

--- a/packages/core/src/api/apiTypes.ts
+++ b/packages/core/src/api/apiTypes.ts
@@ -78,9 +78,6 @@ export interface ApiRequest extends ApiBase {
     // We should only accept server side proxy requests if proxy is defined
     proxy?: {
       enabled: { formula: Formula }
-      // Allow replacing template values in the body of a proxied request
-      // This is useful for cases where the body should include an http only cookie for instance
-      useTemplatesInBody?: boolean
     } | null
     ssr?: {
       // We should only fetch a request server side during SSR if this is true

--- a/packages/core/src/api/apiTypes.ts
+++ b/packages/core/src/api/apiTypes.ts
@@ -78,6 +78,9 @@ export interface ApiRequest extends ApiBase {
     // We should only accept server side proxy requests if proxy is defined
     proxy?: {
       enabled: { formula: Formula }
+      // Allow replacing template values in the body of a proxied request
+      // This is useful for cases where the body should include an http only cookie for instance
+      useTemplatesInBody?: boolean
     } | null
     ssr?: {
       // We should only fetch a request server side during SSR if this is true

--- a/packages/core/src/api/apiTypes.ts
+++ b/packages/core/src/api/apiTypes.ts
@@ -78,6 +78,9 @@ export interface ApiRequest extends ApiBase {
     // We should only accept server side proxy requests if proxy is defined
     proxy?: {
       enabled: { formula: Formula }
+      // Allow replacing template values in the body of a proxied request
+      // This is useful for cases where the body should include an http only cookie for instance
+      useTemplatesInBody?: { formula: Formula } | null
     } | null
     ssr?: {
       // We should only fetch a request server side during SSR if this is true

--- a/packages/core/src/utils/url.ts
+++ b/packages/core/src/utils/url.ts
@@ -33,6 +33,8 @@ export const validateUrl = ({
   }
 }
 
-export const PROXY_URL_HEADER = 'x-toddle-url'
+export const PROXY_URL_HEADER = 'x-nordcraft-url'
 
-export const REWRITE_HEADER = 'x-toddle-rewrite'
+export const PROXY_TEMPLATES_IN_BODY = 'x-nordcraft-templates-in-body'
+
+export const REWRITE_HEADER = 'x-nordcraft-rewrite'

--- a/packages/runtime/src/api/createAPIv2.ts
+++ b/packages/runtime/src/api/createAPIv2.ts
@@ -30,8 +30,12 @@ import {
   omitPaths,
   sortObjectEntries,
 } from '@nordcraft/core/dist/utils/collections'
-import { PROXY_URL_HEADER, validateUrl } from '@nordcraft/core/dist/utils/url'
-import { isDefined } from '@nordcraft/core/dist/utils/util'
+import {
+  PROXY_TEMPLATES_IN_BODY,
+  PROXY_URL_HEADER,
+  validateUrl,
+} from '@nordcraft/core/dist/utils/url'
+import { isDefined, toBoolean } from '@nordcraft/core/dist/utils/util'
 import { handleAction } from '../events/handleAction'
 import type { Signal } from '../signal/signal'
 import type { ComponentContext, ContextApiV2 } from '../types'
@@ -411,6 +415,15 @@ export function createAPI({
             PROXY_URL_HEADER,
             decodeURIComponent(url.href.replace(/\+/g, ' ')),
           )
+          const allowBodyTemplateValues = toBoolean(
+            applyFormula(
+              api.server?.proxy?.useTemplatesInBody?.formula,
+              getFormulaContext(api, componentData),
+            ),
+          )
+          if (allowBodyTemplateValues) {
+            headers.set(PROXY_TEMPLATES_IN_BODY, 'true')
+          }
           requestSettings.headers = headers
           response = await fetch(proxyUrl, requestSettings)
         }

--- a/packages/search/src/rules/apis/invalidApiProxyBodySettingRule.test.ts
+++ b/packages/search/src/rules/apis/invalidApiProxyBodySettingRule.test.ts
@@ -1,0 +1,80 @@
+import { valueFormula } from '@nordcraft/core/dist/formula/formulaUtils'
+import { describe, expect, test } from 'bun:test'
+import { searchProject } from '../../searchProject'
+import { invalidApiProxyBodySettingRule } from './invalidApiProxyBodySettingRule'
+
+describe('invalidApiProxyBodySetting', () => {
+  test('should report invalid proxy body settings for an API with proxying disabled', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          components: {
+            test: {
+              name: 'test',
+              nodes: {},
+              formulas: {},
+              apis: {
+                'my-api': {
+                  name: 'my-api',
+                  type: 'http',
+                  version: 2,
+                  autoFetch: valueFormula(true),
+                  inputs: {},
+                  server: {
+                    proxy: {
+                      enabled: { formula: valueFormula(false) },
+                      useTemplatesInBody: { formula: valueFormula(true) },
+                    },
+                  },
+                },
+              },
+              attributes: {},
+              variables: {},
+            },
+          },
+        },
+        rules: [invalidApiProxyBodySettingRule],
+      }),
+    )
+
+    expect(problems).toHaveLength(1)
+    expect(problems[0].code).toBe('invalid api proxy body setting')
+    expect(problems[0].details).toEqual({ api: 'my-api' })
+  })
+
+  test('should not report valid body proxy settings', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          components: {
+            test: {
+              name: 'test',
+              nodes: {},
+              formulas: {},
+              apis: {
+                'my-api': {
+                  name: 'my-api',
+                  type: 'http',
+                  version: 2,
+                  autoFetch: valueFormula(true),
+                  inputs: {},
+                  server: {
+                    proxy: {
+                      enabled: { formula: valueFormula(true) },
+                      useTemplatesInBody: { formula: valueFormula(true) },
+                    },
+                  },
+                },
+              },
+              attributes: {},
+              variables: {},
+            },
+          },
+        },
+        rules: [invalidApiProxyBodySettingRule],
+      }),
+    )
+
+    expect(problems).toEqual([])
+  })
+})

--- a/packages/search/src/rules/apis/invalidApiProxyBodySettingRule.ts
+++ b/packages/search/src/rules/apis/invalidApiProxyBodySettingRule.ts
@@ -1,0 +1,25 @@
+import { isLegacyApi } from '@nordcraft/core/dist/api/api'
+import type { Rule } from '../../types'
+
+export const invalidApiProxyBodySettingRule: Rule<{ api: string }> = {
+  code: 'invalid api proxy body setting',
+  level: 'warning',
+  category: 'Quality',
+  visit: (report, args) => {
+    if (args.nodeType !== 'component-api') {
+      return
+    }
+    const { path, value } = args
+    if (
+      isLegacyApi(value) ||
+      value.server?.proxy?.useTemplatesInBody?.formula.type !== 'value' ||
+      value.server.proxy.useTemplatesInBody.formula.value === false ||
+      (value.server.proxy.enabled.formula.type === 'value' &&
+        value.server.proxy.enabled.formula.value === true)
+    ) {
+      return
+    }
+    // Report an issue if useTemplatesInBody is set to true while the API is not set to be proxied
+    report(path, { api: value.name })
+  },
+}

--- a/packages/search/src/types.d.ts
+++ b/packages/search/src/types.d.ts
@@ -28,6 +28,7 @@ type Code =
   | 'duplicate workflow parameter'
   | 'duplicate route'
   | 'invalid api parser mode'
+  | 'invalid api proxy body setting'
   | 'legacy action'
   | 'legacy api'
   | 'legacy formula'

--- a/packages/ssr/src/rendering/template.ts
+++ b/packages/ssr/src/rendering/template.ts
@@ -1,7 +1,7 @@
 import { STRING_TEMPLATE } from '@nordcraft/core/dist/api/template'
 import type { ToddleServerEnv } from '@nordcraft/core/dist/formula/formula'
 import { isDefined } from '@nordcraft/core/dist/utils/util'
-import { skipCookieHeader, skipNordcraftHeader } from '../utils/headers'
+import { skipCookieHeader, skipNordcraftHeaders } from '../utils/headers'
 
 export const applyTemplateValues = (
   input: string | null | undefined,
@@ -43,7 +43,7 @@ export const sanitizeProxyHeaders = ({
   new Headers(
     mapTemplateHeaders({
       cookies,
-      headers: skipCookieHeader(skipNordcraftHeader(headers)),
+      headers: skipCookieHeader(skipNordcraftHeaders(headers)),
     }),
   )
 

--- a/packages/ssr/src/rendering/template.ts
+++ b/packages/ssr/src/rendering/template.ts
@@ -1,7 +1,7 @@
 import { STRING_TEMPLATE } from '@nordcraft/core/dist/api/template'
 import type { ToddleServerEnv } from '@nordcraft/core/dist/formula/formula'
 import { isDefined } from '@nordcraft/core/dist/utils/util'
-import { skipCookieHeader, skipToddleHeader } from '../utils/headers'
+import { skipCookieHeader, skipNordcraftHeader } from '../utils/headers'
 
 export const applyTemplateValues = (
   input: string | null | undefined,
@@ -43,7 +43,7 @@ export const sanitizeProxyHeaders = ({
   new Headers(
     mapTemplateHeaders({
       cookies,
-      headers: skipCookieHeader(skipToddleHeader(headers)),
+      headers: skipCookieHeader(skipNordcraftHeader(headers)),
     }),
   )
 

--- a/packages/ssr/src/utils/headers.ts
+++ b/packages/ssr/src/utils/headers.ts
@@ -1,4 +1,7 @@
-import { PROXY_URL_HEADER } from '@nordcraft/core/dist/utils/url'
+import {
+  PROXY_TEMPLATES_IN_BODY,
+  PROXY_URL_HEADER,
+} from '@nordcraft/core/dist/utils/url'
 
 /**
  * Omit the `cookie` header from a set of headers.
@@ -16,8 +19,9 @@ export const skipCookieHeader = (headers: Headers) => {
  * Since this header is only relevant for Nordcraft requests, it's not useful
  * for other services to receive this.
  */
-export const skipNordcraftHeader = (headers: Headers) => {
+export const skipNordcraftHeaders = (headers: Headers) => {
   const newHeaders = new Headers(headers)
   newHeaders.delete(PROXY_URL_HEADER)
+  newHeaders.delete(PROXY_TEMPLATES_IN_BODY)
   return newHeaders
 }

--- a/packages/ssr/src/utils/headers.ts
+++ b/packages/ssr/src/utils/headers.ts
@@ -12,11 +12,11 @@ export const skipCookieHeader = (headers: Headers) => {
 }
 
 /**
- * Omit the x-toddle-url header from a set of headers.
- * Since this header is only relevant for toddle requests, it's not useful
+ * Omit the x-nordcraft-url header from a set of headers.
+ * Since this header is only relevant for Nordcraft requests, it's not useful
  * for other services to receive this.
  */
-export const skipToddleHeader = (headers: Headers) => {
+export const skipNordcraftHeader = (headers: Headers) => {
   const newHeaders = new Headers(headers)
   newHeaders.delete(PROXY_URL_HEADER)
   return newHeaders

--- a/packages/ssr/src/utils/headers.ts
+++ b/packages/ssr/src/utils/headers.ts
@@ -15,9 +15,9 @@ export const skipCookieHeader = (headers: Headers) => {
 }
 
 /**
- * Omit the x-nordcraft-url header from a set of headers.
- * Since this header is only relevant for Nordcraft requests, it's not useful
- * for other services to receive this.
+ * Omit the "x-nordcraft-url" and "x-nordcraft-templates-in-body" headers
+ * from a set of headers. Since these headers are only relevant for the
+ * Nordcraft API proxy, it's not useful for other services to receive them
  */
 export const skipNordcraftHeaders = (headers: Headers) => {
   const newHeaders = new Headers(headers)


### PR DESCRIPTION
To support use cases like refreshing access tokens, we must allow injecting cookie template values in the body of proxied requests. This will be an opt in, and we will only process the body during proxying when the special header is set/available.

- Add tests for proxied API requests
- Rename header for destination URL for proxied requests
- Make sure we run backend tests in CI