### PR TITLE
Respect duplicate headers in API responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nordcraft",
   "type": "module",
   "license": "Apache-2.0",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "homepage": "https://github.com/nordcraftengine/nordcraft",
   "private": "false",
   "workspaces": [

--- a/packages/backend/src/routes/apiProxy.ts
+++ b/packages/backend/src/routes/apiProxy.ts
@@ -81,7 +81,7 @@ export const proxyRequestHandler = async (
 
     const returnResponse = new Response(body, {
       status: response.status,
-      headers: Object.fromEntries(response.headers),
+      headers: new Headers(response.headers),
     })
     return returnResponse
   } catch (e) {

--- a/packages/backend/src/utils/api.ts
+++ b/packages/backend/src/utils/api.ts
@@ -11,7 +11,11 @@ import type {
   LegacyApiStatus,
   RedirectStatusCode,
 } from '@nordcraft/core/dist/api/apiTypes'
-import { isJsonHeader, isTextHeader } from '@nordcraft/core/dist/api/headers'
+import {
+  isJsonHeader,
+  isTextHeader,
+  mapHeadersToObject,
+} from '@nordcraft/core/dist/api/headers'
 import { ToddleApiV2 } from '@nordcraft/core/dist/api/ToddleApiV2'
 import type { FormulaContext } from '@nordcraft/core/dist/formula/formula'
 import { applyFormula } from '@nordcraft/core/dist/formula/formula'
@@ -157,7 +161,7 @@ const fetchApi = async ({
     formulaContext,
     baseUrl: url.origin,
     defaultHeaders: new Headers({
-      ...Object.fromEntries(req.headers.entries()),
+      ...mapHeadersToObject(req.headers),
       // Override accept + accept-encoding to increase the chance that we can work with the response
       // from an API fetched during SSR. Many servers don't support br encoding for instance.
       accept: '*/*',
@@ -239,7 +243,7 @@ const fetchApiV2 = async ({
       error: `Error getting response body: ${e}`,
       response: {
         status: 500,
-        headers: Object.fromEntries(response.headers.entries()),
+        headers: mapHeadersToObject(response.headers),
       },
     }
   }
@@ -251,7 +255,7 @@ const fetchApiV2 = async ({
       body: responseBody,
       ok: response.ok,
       status: response.status,
-      headers: Object.fromEntries(response.headers.entries()),
+      headers: mapHeadersToObject(response.headers),
     },
     formulaContext,
     errorFormula,
@@ -264,7 +268,7 @@ const fetchApiV2 = async ({
     error: isError ? (responseBody ?? response.statusText) : null,
     response: {
       status: response.status,
-      headers: Object.fromEntries(response.headers.entries()),
+      headers: mapHeadersToObject(response.headers),
       performance,
     },
   }

--- a/packages/core/src/api/headers.test.ts
+++ b/packages/core/src/api/headers.test.ts
@@ -1,0 +1,17 @@
+import { mapHeadersToObject } from './headers'
+
+describe('mapHeadersToObject()', () => {
+  test('it maps Headers to a plain object', () => {
+    const headers = mapHeadersToObject(
+      new Headers([
+        ['accept', 'application/json'],
+        ['origin', 'my.origin.com'],
+        ['set-cookie', 'sessionId=12345'],
+        ['set-cookie', 'userId=67890'],
+      ]),
+    )
+    expect(headers['accept']).toEqual('application/json')
+    expect(headers['origin']).toEqual('my.origin.com')
+    expect(headers['set-cookie']).toBe('sessionId=12345, userId=67890')
+  })
+})

--- a/packages/core/src/api/headers.ts
+++ b/packages/core/src/api/headers.ts
@@ -39,3 +39,19 @@ export const isImageHeader = (header?: string | null) => {
   }
   return /^image\//.test(header)
 }
+
+/**
+ * Returns an object with headers from a Headers object
+ * Duplicate header values (set-cookie for instance) are encoded as a comma-separated string
+ */
+export const mapHeadersToObject = (headers: Headers) => {
+  const headersObject: Record<string, string> = {}
+  for (const [key, value] of headers.entries()) {
+    if (headersObject[key]) {
+      headersObject[key] += `, ${value}`
+    } else {
+      headersObject[key] = value
+    }
+  }
+  return headersObject
+}

--- a/packages/runtime/src/api/createAPI.ts
+++ b/packages/runtime/src/api/createAPI.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
 import type { LegacyComponentAPI } from '@nordcraft/core/dist/api/apiTypes'
+import { mapHeadersToObject } from '@nordcraft/core/dist/api/headers'
 import type { ComponentData } from '@nordcraft/core/dist/component/component.types'
 import { applyFormula, isFormula } from '@nordcraft/core/dist/formula/formula'
 import { mapValues } from '@nordcraft/core/dist/utils/collections'
@@ -362,10 +363,7 @@ export function createLegacyAPI(
         url: request?.url ?? apiPayload.url,
         method: request?.method ?? apiPayload.method,
         auth: request?.auth ?? apiPayload.auth,
-        headers: [...headers.entries()].reduce<Record<string, string>>(
-          (acc, [key, value]) => ({ ...acc, [key]: value }),
-          {},
-        ),
+        headers: mapHeadersToObject(headers),
         body,
       }
       return trigger(payload)

--- a/packages/runtime/src/api/createAPIv2.ts
+++ b/packages/runtime/src/api/createAPIv2.ts
@@ -17,6 +17,7 @@ import {
   isJsonHeader,
   isJsonStreamHeader,
   isTextHeader,
+  mapHeadersToObject,
 } from '@nordcraft/core/dist/api/headers'
 import type { ComponentData } from '@nordcraft/core/dist/component/component.types'
 import type {
@@ -582,7 +583,7 @@ export function createAPI({
       error: null,
       response: {
         status: res.status,
-        headers: Object.fromEntries(res.headers.entries()),
+        headers: mapHeadersToObject(res.headers),
       },
     }
     return endResponse({ api, apiStatus: status, componentData, performance })
@@ -607,7 +608,7 @@ export function createAPI({
       error: null,
       response: {
         status: res.status,
-        headers: Object.fromEntries(res.headers.entries()),
+        headers: mapHeadersToObject(res.headers),
       },
     }
     return endResponse({ api, apiStatus: status, componentData, performance })
@@ -700,7 +701,7 @@ export function createAPI({
                 data: parseChunksForData(this.chunks),
                 error: null,
                 response: {
-                  headers: Object.fromEntries(res.headers.entries()),
+                  headers: mapHeadersToObject(res.headers),
                 },
               },
             },
@@ -754,7 +755,7 @@ export function createAPI({
       error: null,
       response: {
         status: res.status,
-        headers: Object.fromEntries(res.headers.entries()),
+        headers: mapHeadersToObject(res.headers),
       },
     }
 

--- a/packages/ssr/src/rendering/formulaContext.ts
+++ b/packages/ssr/src/rendering/formulaContext.ts
@@ -1,3 +1,4 @@
+import { mapHeadersToObject } from '@nordcraft/core/dist/api/headers'
 import type {
   PageComponent,
   PageRoute,
@@ -180,7 +181,7 @@ export const serverEnv = ({
     // isServer will be true for SSR + proxied requests
     isServer: true,
     request: {
-      headers: Object.fromEntries(req.headers.entries()),
+      headers: mapHeadersToObject(req.headers),
       cookies: getRequestCookies(req),
       url: req.url,
     },


### PR DESCRIPTION
Proxied API requests would loose information about duplicate headers (multiple `set-cookie` headers for instance). This change ensures that all headers are preserved and accessible in the API response.

It also introduces a utility function to merge duplicate headers (by comma separating them) when needed, which is useful for headers like `set-cookie`.

This issue was reported (for proxied API requests) here https://discord.com/channels/972416966683926538/1378707406363824128