### PR TITLE
Only skip exported components in packages

### DIFF
--- a/packages/runtime/src/editor-preview.main.ts
+++ b/packages/runtime/src/editor-preview.main.ts
@@ -102,7 +102,7 @@ type ToddlePreviewEvent =
   | { type: 'keyup'; key: string; altKey: boolean; metaKey: boolean }
   | {
       type: 'get_computed_style'
-      styles: string[]
+      styles?: string[]
     }
   | {
       type: 'set_timeline_keyframes'
@@ -863,7 +863,7 @@ export const createRoot = (
             {
               type: 'computedStyle',
               computedStyle: Object.fromEntries(
-                styles.map((style) => [
+                (styles ?? []).map((style) => [
                   style,
                   computedStyle.getPropertyValue(style),
                 ]),

--- a/packages/search/src/rules/components/noReferenceComponentRule.test.ts
+++ b/packages/search/src/rules/components/noReferenceComponentRule.test.ts
@@ -42,6 +42,14 @@ describe('noReferenceComponentRule', () => {
           },
         },
         rules: [noReferenceComponentRule],
+        state: {
+          projectDetails: {
+            type: 'package',
+            id: 'test-project-id',
+            name: 'test-project',
+            short_id: 'test-project-id',
+          },
+        },
       }),
     )
 
@@ -137,5 +145,71 @@ describe('noReferenceComponentRule', () => {
     )
 
     expect(problems).toEqual([])
+  })
+
+  test('should not report exported components for package projects', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          formulas: {},
+          components: {
+            orphan: {
+              name: 'test',
+              nodes: {},
+              formulas: {},
+              apis: {},
+              attributes: {},
+              variables: {},
+              exported: true,
+            },
+          },
+        },
+        state: {
+          projectDetails: {
+            type: 'package',
+            id: 'test-package-id',
+            name: 'test-package',
+            short_id: 'test-package-id',
+          },
+        },
+        rules: [noReferenceComponentRule],
+      }),
+    )
+
+    expect(problems).toEqual([])
+  })
+
+  test('should still report exported components for non-package projects', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          formulas: {},
+          components: {
+            exportedOrphan: {
+              name: 'test',
+              nodes: {},
+              formulas: {},
+              apis: {},
+              attributes: {},
+              variables: {},
+              exported: true,
+            },
+          },
+        },
+        state: {
+          projectDetails: {
+            type: 'app',
+            id: 'test-project-id',
+            name: 'test-project',
+            short_id: 'test-project-id',
+          },
+        },
+        rules: [noReferenceComponentRule],
+      }),
+    )
+
+    expect(problems).toHaveLength(1)
+    expect(problems[0].code).toBe('no-reference component')
+    expect(problems[0].path).toEqual(['components', 'exportedOrphan'])
   })
 })

--- a/packages/search/src/rules/components/noReferenceComponentRule.ts
+++ b/packages/search/src/rules/components/noReferenceComponentRule.ts
@@ -6,9 +6,13 @@ export const noReferenceComponentRule: Rule<void> = {
   code: 'no-reference component',
   level: 'warning',
   category: 'No References',
-  visit: (report, { path, nodeType, files, value }) => {
+  visit: (report, { path, nodeType, files, value }, state) => {
     // We need a way to flag if a component is exported as a web component, as it would be a valid orphan
-    if (nodeType !== 'component' || isPage(value) || value.exported === true) {
+    if (
+      nodeType !== 'component' ||
+      isPage(value) ||
+      (state?.projectDetails?.type === 'package' && value.exported === true)
+    ) {
       return
     }
 

--- a/packages/search/src/types.d.ts
+++ b/packages/search/src/types.d.ts
@@ -19,6 +19,7 @@ import type {
   PluginAction,
   ProjectFiles,
   Route,
+  ToddleProject,
 } from '@nordcraft/ssr/dist/ssr.types'
 
 type Code =
@@ -129,6 +130,7 @@ type NonHttpOnlyCookie = ApplicationCookie & {
 export interface ApplicationState {
   cookiesAvailable?: Array<HttpOnlyCookie | NonHttpOnlyCookie>
   isBrowserExtensionAvailable?: boolean
+  projectDetails?: ToddleProject
 }
 
 type Base = {


### PR DESCRIPTION
Some components would not be reported as unused if they were copy/pasted from packages with `exported = true`.

This requires an editor update before mergin.