### PR TITLE
Fixed an issue where non-auto-fetch apis would clear its data if its url was updated.

### DIFF
--- a/packages/runtime/src/api/createAPIv2.ts
+++ b/packages/runtime/src/api/createAPIv2.ts
@@ -941,7 +941,9 @@ export function createAPI({
           requestSettings,
           componentData: initialComponentData,
         })
-      } else {
+      } else if (!ctx.dataSignal.get().Apis?.[api.name]) {
+        // If the api is not set in the dataSignal, we need to initialize it.
+        // If it is set and autoFetch is false, we do not want to reset it.
         ctx.dataSignal.update((data) => {
           return {
             ...data,


### PR DESCRIPTION
This PR ensures that APIs that doesn't auto fetch will persist its data even when a parameter changes that would void the data (fx a query param). This is solved by making sure we only initialize the api once and never clear it unless its a new request.