### PR TITLE
Adjust redirect handling to include route name

### DIFF
--- a/packages/backend/src/routes/nordcraftPage.ts
+++ b/packages/backend/src/routes/nordcraftPage.ts
@@ -15,6 +15,10 @@ import {
 import { getCharset, getHtmlLanguage } from '@nordcraft/ssr/dist/rendering/html'
 import type { ProjectFiles, ToddleProject } from '@nordcraft/ssr/dist/ssr.types'
 import { removeTestData } from '@nordcraft/ssr/src/rendering/testData'
+import {
+  REDIRECT_API_NAME_HEADER,
+  REDIRECT_COMPONENT_NAME_HEADER,
+} from '@nordcraft/ssr/src/utils/headers'
 import type { Context } from 'hono'
 import { html, raw } from 'hono/html'
 import type { HonoEnv } from '../../hono'
@@ -117,8 +121,8 @@ export const nordcraftPage = async ({
         status: e.redirect.statusCode ?? 302,
         // Header for helping the client (user) know which API caused the redirect
         headers: {
-          'x-nordcraft-redirect-api-name': e.redirect.apiName,
-          'x-nordcraft-redirect-component-name': e.redirect.componentName,
+          [REDIRECT_API_NAME_HEADER]: e.redirect.apiName,
+          [REDIRECT_COMPONENT_NAME_HEADER]: e.redirect.componentName,
           location: e.redirect.url.href,
         },
       })

--- a/packages/backend/src/routes/pageHandler.ts
+++ b/packages/backend/src/routes/pageHandler.ts
@@ -12,10 +12,7 @@ export const pageHandler: MiddlewareHandler<
   const url = new URL(ctx.req.url)
   const page = matchPageForUrl({
     url,
-    pages: Object.values(ctx.var.routes.pages).map((p) => ({
-      name: p.name,
-      route: p.route,
-    })),
+    pages: Object.values(ctx.var.routes.pages),
   })
   if (page) {
     const pageContent = await loadJsFile<

--- a/packages/backend/src/routes/pageHandler.ts
+++ b/packages/backend/src/routes/pageHandler.ts
@@ -12,7 +12,10 @@ export const pageHandler: MiddlewareHandler<
   const url = new URL(ctx.req.url)
   const page = matchPageForUrl({
     url,
-    components: ctx.var.routes.pages,
+    pages: Object.values(ctx.var.routes.pages).map((p) => ({
+      name: p.name,
+      route: p.route,
+    })),
   })
   if (page) {
     const pageContent = await loadJsFile<

--- a/packages/backend/src/routes/routeHandler.ts
+++ b/packages/backend/src/routes/routeHandler.ts
@@ -8,6 +8,7 @@ import {
   getRouteDestination,
   matchRouteForUrl,
 } from '@nordcraft/ssr/dist/routing/routing'
+import { REDIRECT_ROUTE_NAME_HEADER } from '@nordcraft/ssr/src/utils/headers'
 import type { Handler } from 'hono'
 import type { HonoEnv, HonoProject, HonoRoutes } from '../../hono'
 
@@ -16,7 +17,7 @@ export const routeHandler: Handler<HonoEnv<HonoRoutes & HonoProject>> = async (
   next,
 ) => {
   const url = new URL(c.req.url)
-  const route = matchRouteForUrl({
+  const routeMatch = matchRouteForUrl({
     url,
     routes: c.var.routes?.routes ?? {},
     env: serverEnv({ branchName: 'main', req: c.req.raw, logErrors: false }),
@@ -24,9 +25,10 @@ export const routeHandler: Handler<HonoEnv<HonoRoutes & HonoProject>> = async (
     // TODO: We should pass in global Nordcraft formulas from project + packages here
     serverContext: getServerToddleObject({} as any),
   })
-  if (!route) {
+  if (!routeMatch) {
     return next()
   }
+  const { route, name: routeName } = routeMatch
   const destination = getRouteDestination({
     // might not want to use main branch here
     env: serverEnv({ branchName: 'main', req: c.req.raw, logErrors: false }),
@@ -42,7 +44,13 @@ export const routeHandler: Handler<HonoEnv<HonoRoutes & HonoProject>> = async (
   }
   if (route.type === 'redirect') {
     // Return a redirect to the destination with the provided status code
-    return c.redirect(destination.href, route.status ?? 302)
+    return new Response(null, {
+      headers: {
+        location: destination.href,
+        [REDIRECT_ROUTE_NAME_HEADER]: routeName,
+      },
+      status: route.status ?? 302,
+    })
   }
 
   // Rewrite handling: fetch the destination and return the response

--- a/packages/backend/src/routes/routeHandler.ts
+++ b/packages/backend/src/routes/routeHandler.ts
@@ -8,7 +8,7 @@ import {
   getRouteDestination,
   matchRouteForUrl,
 } from '@nordcraft/ssr/dist/routing/routing'
-import { REDIRECT_ROUTE_NAME_HEADER } from '@nordcraft/ssr/src/utils/headers'
+import { REDIRECT_NAME_HEADER } from '@nordcraft/ssr/src/utils/headers'
 import type { Handler } from 'hono'
 import type { HonoEnv, HonoProject, HonoRoutes } from '../../hono'
 
@@ -47,7 +47,7 @@ export const routeHandler: Handler<HonoEnv<HonoRoutes & HonoProject>> = async (
     return new Response(null, {
       headers: {
         location: destination.href,
-        [REDIRECT_ROUTE_NAME_HEADER]: routeName,
+        [REDIRECT_NAME_HEADER]: routeName,
       },
       status: route.status ?? 302,
     })

--- a/packages/ssr/src/routing/routing.test.ts
+++ b/packages/ssr/src/routing/routing.test.ts
@@ -1,4 +1,4 @@
-import type { RouteDeclaration } from '@nordcraft/core/dist/component/component.types'
+import type { PageComponent } from '@nordcraft/core/dist/component/component.types'
 import { valueFormula } from '@nordcraft/core/dist/formula/formulaUtils'
 import { describe, expect, test } from 'bun:test'
 import { serverEnv } from '../rendering/formulaContext'
@@ -7,22 +7,32 @@ import { matchPageForUrl, matchRouteForUrl } from './routing'
 
 describe('matchPageForUrl', () => {
   test('it finds the correct page for a url', () => {
-    const pages: Record<
-      string,
-      {
-        route?: RouteDeclaration | null
-      }
-    > = {
+    const pages: Record<string, PageComponent> = {
       searchPage: {
+        name: 'searchPage',
+        attributes: {},
+        variables: {},
+        apis: {},
+        nodes: {},
         route: { path: [{ type: 'static', name: 'search' }], query: {} },
       },
       categoryPage: {
+        name: 'categoryPage',
+        attributes: {},
+        variables: {},
+        apis: {},
+        nodes: {},
         route: {
           path: [{ type: 'param', name: 'category', testValue: 'fruit' }],
           query: {},
         },
       },
       docsPage: {
+        name: 'docsPage',
+        attributes: {},
+        variables: {},
+        apis: {},
+        nodes: {},
         route: {
           path: [
             { type: 'static', name: 'docs' },
@@ -32,6 +42,11 @@ describe('matchPageForUrl', () => {
         },
       },
       helloPage: {
+        name: 'helloPage',
+        attributes: {},
+        variables: {},
+        apis: {},
+        nodes: {},
         route: {
           path: [
             { type: 'param', name: 'test', testValue: '' },
@@ -41,6 +56,11 @@ describe('matchPageForUrl', () => {
         },
       },
       otherPage: {
+        name: 'otherPage',
+        attributes: {},
+        variables: {},
+        apis: {},
+        nodes: {},
         route: {
           path: [
             { type: 'param', name: 'other', testValue: '' },
@@ -52,34 +72,39 @@ describe('matchPageForUrl', () => {
     }
 
     const searchUrl = new URL('http://localhost:3000/search')
-    expect(matchPageForUrl({ url: searchUrl, components: pages })).toEqual(
-      pages['searchPage'],
-    )
+    expect(matchPageForUrl({ url: searchUrl, components: pages })).toEqual({
+      name: 'searchPage',
+      route: pages['searchPage'],
+    })
     const categoryUrl = new URL('http://localhost:3000/fruit')
-    expect(matchPageForUrl({ url: categoryUrl, components: pages })).toEqual(
-      pages['categoryPage'],
-    )
+    expect(matchPageForUrl({ url: categoryUrl, components: pages })).toEqual({
+      name: 'categoryPage',
+      route: pages['categoryPage'],
+    })
     const docsUrl = new URL('http://localhost:3000/docs/intro')
-    expect(matchPageForUrl({ url: docsUrl, components: pages })).toEqual(
-      pages['docsPage'],
-    )
+    expect(matchPageForUrl({ url: docsUrl, components: pages })).toEqual({
+      name: 'docsPage',
+      route: pages['docsPage'],
+    })
     const helloUrl = new URL('http://localhost:3000/bla/hello')
-    expect(matchPageForUrl({ url: helloUrl, components: pages })).toEqual(
-      pages['helloPage'],
-    )
+    expect(matchPageForUrl({ url: helloUrl, components: pages })).toEqual({
+      name: 'helloPage',
+      route: pages['helloPage'],
+    })
     const otherUrl = new URL('http://localhost:3000/hello/world')
-    expect(matchPageForUrl({ url: otherUrl, components: pages })).toEqual(
-      pages['otherPage'],
-    )
+    expect(matchPageForUrl({ url: otherUrl, components: pages })).toEqual({
+      name: 'otherPage',
+      route: pages['otherPage'],
+    })
   })
   test('it prefers static path segments in urls', () => {
-    const pages: Record<
-      string,
-      {
-        route?: RouteDeclaration | null
-      }
-    > = {
+    const pages: Record<string, PageComponent> = {
       otherPage: {
+        name: 'otherPage',
+        attributes: {},
+        variables: {},
+        apis: {},
+        nodes: {},
         route: {
           path: [
             // /:other/:page
@@ -90,6 +115,11 @@ describe('matchPageForUrl', () => {
         },
       },
       guidesPage: {
+        name: 'guidesPage',
+        attributes: {},
+        variables: {},
+        apis: {},
+        nodes: {},
         route: {
           path: [
             // /guides/:p1/:p2
@@ -102,40 +132,49 @@ describe('matchPageForUrl', () => {
       },
     }
     const guidesUrl = new URL('http://localhost:3000/guides/category/explore')
-    expect(matchPageForUrl({ url: guidesUrl, components: pages })).toEqual(
-      pages['guidesPage'],
-    )
+    expect(matchPageForUrl({ url: guidesUrl, components: pages })).toEqual({
+      name: 'guidesPage',
+      route: pages['guidesPage'],
+    })
     const guidesUrl2 = new URL('http://localhost:3000/guides')
-    expect(matchPageForUrl({ url: guidesUrl2, components: pages })).toEqual(
-      pages['guidesPage'],
-    )
+    expect(matchPageForUrl({ url: guidesUrl2, components: pages })).toEqual({
+      name: 'guidesPage',
+      route: pages['guidesPage'],
+    })
     const guidesUrl3 = new URL('http://localhost:3000/test')
-    expect(matchPageForUrl({ url: guidesUrl3, components: pages })).toEqual(
-      pages['otherPage'],
-    )
+    expect(matchPageForUrl({ url: guidesUrl3, components: pages })).toEqual({
+      name: 'otherPage',
+      route: pages['otherPage'],
+    })
     const guidesUrl4 = new URL('http://localhost:3000/test/hello')
-    expect(matchPageForUrl({ url: guidesUrl4, components: pages })).toEqual(
-      pages['otherPage'],
-    )
+    expect(matchPageForUrl({ url: guidesUrl4, components: pages })).toEqual({
+      name: 'otherPage',
+      route: pages['otherPage'],
+    })
     const guidesUrl5 = new URL('http://localhost:3000/test/hello/world')
     expect(
       matchPageForUrl({ url: guidesUrl5, components: pages }),
     ).toBeUndefined()
   })
   test('it does not find a match for unknown paths', () => {
-    const pages: Record<
-      string,
-      {
-        route?: RouteDeclaration | null
-      }
-    > = {
+    const pages: Record<string, PageComponent> = {
       otherPage: {
+        name: 'otherPage',
+        attributes: {},
+        variables: {},
+        apis: {},
+        nodes: {},
         route: {
           path: [{ type: 'static', name: 'search' }],
           query: {},
         },
       },
       guidesPage: {
+        name: 'guidesPage',
+        attributes: {},
+        variables: {},
+        apis: {},
+        nodes: {},
         route: {
           path: [
             // /:other/page
@@ -210,7 +249,7 @@ describe('matchRouteForUrl', () => {
           getCustomFormula: () => undefined,
         },
       }),
-    ).toEqual(routes['docsRedirect'])
+    ).toEqual({ name: 'docsRedirect', route: routes['docsRedirect'] })
   })
   test('it ignores disabled routes', () => {
     const routes: Record<string, Route> = {
@@ -273,6 +312,6 @@ describe('matchRouteForUrl', () => {
           getCustomFormula: () => undefined,
         },
       }),
-    ).toEqual(routes['docsRedirect'])
+    ).toEqual({ name: 'docsRedirect', route: routes['docsRedirect'] })
   })
 })

--- a/packages/ssr/src/routing/routing.test.ts
+++ b/packages/ssr/src/routing/routing.test.ts
@@ -7,174 +7,134 @@ import { matchPageForUrl, matchRouteForUrl } from './routing'
 
 describe('matchPageForUrl', () => {
   test('it finds the correct page for a url', () => {
-    const pages: Record<string, PageComponent> = {
-      searchPage: {
-        name: 'searchPage',
-        attributes: {},
-        variables: {},
-        apis: {},
-        nodes: {},
-        route: { path: [{ type: 'static', name: 'search' }], query: {} },
-      },
-      categoryPage: {
-        name: 'categoryPage',
-        attributes: {},
-        variables: {},
-        apis: {},
-        nodes: {},
-        route: {
-          path: [{ type: 'param', name: 'category', testValue: 'fruit' }],
-          query: {},
-        },
-      },
-      docsPage: {
-        name: 'docsPage',
-        attributes: {},
-        variables: {},
-        apis: {},
-        nodes: {},
-        route: {
-          path: [
-            { type: 'static', name: 'docs' },
-            { type: 'param', testValue: '', name: 'docs-page' },
-          ],
-          query: {},
-        },
-      },
-      helloPage: {
-        name: 'helloPage',
-        attributes: {},
-        variables: {},
-        apis: {},
-        nodes: {},
-        route: {
-          path: [
-            { type: 'param', name: 'test', testValue: '' },
-            { type: 'static', name: 'hello' },
-          ],
-          query: {},
-        },
-      },
-      otherPage: {
-        name: 'otherPage',
-        attributes: {},
-        variables: {},
-        apis: {},
-        nodes: {},
-        route: {
-          path: [
-            { type: 'param', name: 'other', testValue: '' },
-            { type: 'param', name: 'page', testValue: '' },
-          ],
-          query: {},
-        },
+    const searchPage: Pick<PageComponent, 'name' | 'route'> = {
+      name: 'searchPage',
+      route: { path: [{ type: 'static', name: 'search' }], query: {} },
+    }
+    const categoryPage: Pick<PageComponent, 'name' | 'route'> = {
+      name: 'categoryPage',
+      route: {
+        path: [{ type: 'param', name: 'category', testValue: 'fruit' }],
+        query: {},
       },
     }
+    const docsPage: Pick<PageComponent, 'name' | 'route'> = {
+      name: 'docsPage',
+      route: {
+        path: [
+          { type: 'static', name: 'docs' },
+          { type: 'param', testValue: '', name: 'docs-page' },
+        ],
+        query: {},
+      },
+    }
+    const helloPage: Pick<PageComponent, 'name' | 'route'> = {
+      name: 'helloPage',
+      route: {
+        path: [
+          { type: 'param', name: 'test', testValue: '' },
+          { type: 'static', name: 'hello' },
+        ],
+        query: {},
+      },
+    }
+    const otherPage: Pick<PageComponent, 'name' | 'route'> = {
+      name: 'otherPage',
+      route: {
+        path: [
+          { type: 'param', name: 'other', testValue: '' },
+          { type: 'param', name: 'page', testValue: '' },
+        ],
+        query: {},
+      },
+    }
+    const pages = [searchPage, categoryPage, docsPage, helloPage, otherPage]
 
     const searchUrl = new URL('http://localhost:3000/search')
-    expect(matchPageForUrl({ url: searchUrl, components: pages })).toEqual({
+    expect(matchPageForUrl({ url: searchUrl, pages })).toEqual({
       name: 'searchPage',
-      route: pages['searchPage'],
+      route: searchPage,
     })
     const categoryUrl = new URL('http://localhost:3000/fruit')
-    expect(matchPageForUrl({ url: categoryUrl, components: pages })).toEqual({
+    expect(matchPageForUrl({ url: categoryUrl, pages })).toEqual({
       name: 'categoryPage',
-      route: pages['categoryPage'],
+      route: categoryPage,
     })
     const docsUrl = new URL('http://localhost:3000/docs/intro')
-    expect(matchPageForUrl({ url: docsUrl, components: pages })).toEqual({
+    expect(matchPageForUrl({ url: docsUrl, pages })).toEqual({
       name: 'docsPage',
-      route: pages['docsPage'],
+      route: docsPage,
     })
     const helloUrl = new URL('http://localhost:3000/bla/hello')
-    expect(matchPageForUrl({ url: helloUrl, components: pages })).toEqual({
+    expect(matchPageForUrl({ url: helloUrl, pages })).toEqual({
       name: 'helloPage',
-      route: pages['helloPage'],
+      route: helloPage,
     })
     const otherUrl = new URL('http://localhost:3000/hello/world')
-    expect(matchPageForUrl({ url: otherUrl, components: pages })).toEqual({
+    expect(matchPageForUrl({ url: otherUrl, pages })).toEqual({
       name: 'otherPage',
-      route: pages['otherPage'],
+      route: otherPage,
     })
   })
   test('it prefers static path segments in urls', () => {
-    const pages: Record<string, PageComponent> = {
-      otherPage: {
-        name: 'otherPage',
-        attributes: {},
-        variables: {},
-        apis: {},
-        nodes: {},
-        route: {
-          path: [
-            // /:other/:page
-            { type: 'param', name: 'other', testValue: '' },
-            { type: 'param', name: 'page', testValue: '' },
-          ],
-          query: {},
-        },
-      },
-      guidesPage: {
-        name: 'guidesPage',
-        attributes: {},
-        variables: {},
-        apis: {},
-        nodes: {},
-        route: {
-          path: [
-            // /guides/:p1/:p2
-            { type: 'static', name: 'guides' },
-            { type: 'param', name: 'p1', testValue: '' },
-            { type: 'param', name: 'p2', testValue: '' },
-          ],
-          query: {},
-        },
+    const otherPage: Pick<PageComponent, 'name' | 'route'> = {
+      name: 'otherPage',
+      route: {
+        path: [
+          // /:other/:page
+          { type: 'param', name: 'other', testValue: '' },
+          { type: 'param', name: 'page', testValue: '' },
+        ],
+        query: {},
       },
     }
-    const guidesUrl = new URL('http://localhost:3000/guides/category/explore')
-    expect(matchPageForUrl({ url: guidesUrl, components: pages })).toEqual({
+    const guidesPage: Pick<PageComponent, 'name' | 'route'> = {
       name: 'guidesPage',
-      route: pages['guidesPage'],
+      route: {
+        path: [
+          // /guides/:p1/:p2
+          { type: 'static', name: 'guides' },
+          { type: 'param', name: 'p1', testValue: '' },
+          { type: 'param', name: 'p2', testValue: '' },
+        ],
+        query: {},
+      },
+    }
+    const pages = [otherPage, guidesPage]
+    const guidesUrl = new URL('http://localhost:3000/guides/category/explore')
+    expect(matchPageForUrl({ url: guidesUrl, pages })).toEqual({
+      name: 'guidesPage',
+      route: guidesPage,
     })
     const guidesUrl2 = new URL('http://localhost:3000/guides')
-    expect(matchPageForUrl({ url: guidesUrl2, components: pages })).toEqual({
+    expect(matchPageForUrl({ url: guidesUrl2, pages })).toEqual({
       name: 'guidesPage',
-      route: pages['guidesPage'],
+      route: guidesPage,
     })
     const guidesUrl3 = new URL('http://localhost:3000/test')
-    expect(matchPageForUrl({ url: guidesUrl3, components: pages })).toEqual({
+    expect(matchPageForUrl({ url: guidesUrl3, pages })).toEqual({
       name: 'otherPage',
-      route: pages['otherPage'],
+      route: otherPage,
     })
     const guidesUrl4 = new URL('http://localhost:3000/test/hello')
-    expect(matchPageForUrl({ url: guidesUrl4, components: pages })).toEqual({
+    expect(matchPageForUrl({ url: guidesUrl4, pages })).toEqual({
       name: 'otherPage',
-      route: pages['otherPage'],
+      route: otherPage,
     })
     const guidesUrl5 = new URL('http://localhost:3000/test/hello/world')
-    expect(
-      matchPageForUrl({ url: guidesUrl5, components: pages }),
-    ).toBeUndefined()
+    expect(matchPageForUrl({ url: guidesUrl5, pages })).toBeUndefined()
   })
   test('it does not find a match for unknown paths', () => {
-    const pages: Record<string, PageComponent> = {
-      otherPage: {
+    const pages: Pick<PageComponent, 'name' | 'route'>[] = [
+      {
         name: 'otherPage',
-        attributes: {},
-        variables: {},
-        apis: {},
-        nodes: {},
         route: {
           path: [{ type: 'static', name: 'search' }],
           query: {},
         },
       },
-      guidesPage: {
+      {
         name: 'guidesPage',
-        attributes: {},
-        variables: {},
-        apis: {},
-        nodes: {},
         route: {
           path: [
             // /:other/page
@@ -184,13 +144,11 @@ describe('matchPageForUrl', () => {
           query: {},
         },
       },
-    }
+    ]
     const categoryUrl = new URL('http://localhost:3000/fruit')
-    expect(
-      matchPageForUrl({ url: categoryUrl, components: pages }),
-    ).toBeUndefined()
+    expect(matchPageForUrl({ url: categoryUrl, pages })).toBeUndefined()
     const docsUrl = new URL('http://localhost:3000/docs/intro/help')
-    expect(matchPageForUrl({ url: docsUrl, components: pages })).toBeUndefined()
+    expect(matchPageForUrl({ url: docsUrl, pages })).toBeUndefined()
   })
 })
 describe('matchRouteForUrl', () => {

--- a/packages/ssr/src/routing/routing.ts
+++ b/packages/ssr/src/routing/routing.ts
@@ -14,12 +14,14 @@ import { isDefined, toBoolean } from '@nordcraft/core/dist/utils/util'
 import { getParameters } from '../rendering/formulaContext'
 import type { ProjectFiles, Route } from '../ssr.types'
 
-export const matchPageForUrl = ({
+export const matchPageForUrl = <
+  P extends Pick<PageComponent, 'name' | 'route'>,
+>({
   url,
   pages,
 }: {
   url: URL
-  pages: Pick<PageComponent, 'name' | 'route'>[]
+  pages: P[]
 }) =>
   matchRoutes({
     url,

--- a/packages/ssr/src/routing/routing.ts
+++ b/packages/ssr/src/routing/routing.ts
@@ -1,6 +1,5 @@
 import { getUrl } from '@nordcraft/core/dist/api/api'
 import type {
-  Component,
   PageComponent,
   PageRoute,
   RouteDeclaration,
@@ -17,14 +16,14 @@ import type { ProjectFiles, Route } from '../ssr.types'
 
 export const matchPageForUrl = ({
   url,
-  components,
+  pages,
 }: {
   url: URL
-  components: Partial<Record<string, Component>>
+  pages: Pick<PageComponent, 'name' | 'route'>[]
 }) =>
   matchRoutes({
     url,
-    entries: Object.fromEntries(getPages(components).map((p) => [p.name, p])),
+    entries: Object.fromEntries(pages.map((p) => [p.name, p])),
     getRoute: (page) => page.route,
   })
 

--- a/packages/ssr/src/utils/headers.ts
+++ b/packages/ssr/src/utils/headers.ts
@@ -14,6 +14,11 @@ export const skipCookieHeader = (headers: Headers) => {
   return newHeaders
 }
 
+export const REDIRECT_API_NAME_HEADER = 'x-nordcraft-redirect-api-name'
+export const REDIRECT_COMPONENT_NAME_HEADER =
+  'x-nordcraft-redirect-component-name'
+export const REDIRECT_ROUTE_NAME_HEADER = 'x-nordcraft-redirect-route-name'
+
 /**
  * Omit the "x-nordcraft-url" and "x-nordcraft-templates-in-body" headers
  * from a set of headers. Since these headers are only relevant for the

--- a/packages/ssr/src/utils/headers.ts
+++ b/packages/ssr/src/utils/headers.ts
@@ -17,7 +17,7 @@ export const skipCookieHeader = (headers: Headers) => {
 export const REDIRECT_API_NAME_HEADER = 'x-nordcraft-redirect-api-name'
 export const REDIRECT_COMPONENT_NAME_HEADER =
   'x-nordcraft-redirect-component-name'
-export const REDIRECT_ROUTE_NAME_HEADER = 'x-nordcraft-redirect-route-name'
+export const REDIRECT_NAME_HEADER = 'x-nordcraft-redirect-name'
 
 /**
  * Omit the "x-nordcraft-url" and "x-nordcraft-templates-in-body" headers


### PR DESCRIPTION
When working with more complex redirect setups, it's useful to know which route triggered the redirect. This change adds the route name to the redirect response headers, allowing for easier debugging and tracking of redirects in the application.
Custom Nordcraft header names are now centralized in the ssr package, ensuring consistency and easier management across the codebase.