### PR TITLE
Add dev server as GitHub release assets server

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -136,3 +136,17 @@ jobs:
         run: bun bin/prepareReleaseAssets.ts
       - name: List files
         run: ls -la ./dist
+  test-assets-server:
+    defaults:
+      run:
+        working-directory: ./_assets_dev
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout release
+        uses: actions/checkout@v4
+      - name: Install bun
+        uses: oven-sh/setup-bun@v1
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Typecheck
+        run: bun run typecheck

--- a/_assets_dev/.gitignore
+++ b/_assets_dev/.gitignore
@@ -1,0 +1,3 @@
+# deps
+node_modules/
+.wrangler

--- a/_assets_dev/README.md
+++ b/_assets_dev/README.md
@@ -1,0 +1,3 @@
+## Test server to serve release assets
+
+Run it using `bun run dev`

--- a/_assets_dev/README.md
+++ b/_assets_dev/README.md
@@ -1,3 +1,5 @@
 ## Test server to serve release assets
 
 Run it using `bun run dev`
+
+Try opening http://localhost:1337/reset.css for instance

--- a/_assets_dev/bun.lock
+++ b/_assets_dev/bun.lock
@@ -1,0 +1,21 @@
+{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "github-release-assets",
+      "dependencies": {
+        "hono": "4.7.11",
+      },
+      "devDependencies": {
+        "@types/node": "24.0.3",
+      },
+    },
+  },
+  "packages": {
+    "@types/node": ["@types/node@24.0.3", "", { "dependencies": { "undici-types": "~7.8.0" } }, "sha512-R4I/kzCYAdRLzfiCabn9hxWfbuHS573x+r0dJMkkzThEa7pbrcDWK+9zu3e7aBOouf+rQAciqPFMnxwr0aWgKg=="],
+
+    "hono": ["hono@4.7.11", "", {}, "sha512-rv0JMwC0KALbbmwJDEnxvQCeJh+xbS3KEWW5PC9cMJ08Ur9xgatI0HmtgYZfOdOSOeYsp5LO2cOhdI8cLEbDEQ=="],
+
+    "undici-types": ["undici-types@7.8.0", "", {}, "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw=="],
+  }
+}

--- a/_assets_dev/package.json
+++ b/_assets_dev/package.json
@@ -1,22 +1,15 @@
 {
-  "name": "nordcraft-cloudflare-worker",
+  "name": "github-release-assets",
   "scripts": {
     "predev": "cd .. && bun bin/prepareReleaseAssets.ts",
     "dev": "bun --watch src/index.ts",
-    "build": "bun bin/syncStaticAssets.ts && bunx esbuild --bundle --outdir=dist --platform=node --format=esm src/index.ts",
-    "deploy": "wrangler deploy --no-bundle",
     "typecheck": "tsc --noEmit",
     "watch": "tsc --noEmit -w"
   },
   "dependencies": {
-    "@nordcraft/core": "workspace:*",
-    "@nordcraft/ssr": "workspace:*",
     "hono": "4.7.11"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "4.20250617.0",
-    "@nordcraft/runtime": "workspace:*",
-    "@types/node": "24.0.3",
-    "wrangler": "4.20.0"
+    "@types/node": "24.0.3"
   }
 }

--- a/_assets_dev/package.json
+++ b/_assets_dev/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "nordcraft-cloudflare-worker",
+  "scripts": {
+    "predev": "cd .. && bun bin/prepareReleaseAssets.ts",
+    "dev": "bun --watch src/index.ts",
+    "build": "bun bin/syncStaticAssets.ts && bunx esbuild --bundle --outdir=dist --platform=node --format=esm src/index.ts",
+    "deploy": "wrangler deploy --no-bundle",
+    "typecheck": "tsc --noEmit",
+    "watch": "tsc --noEmit -w"
+  },
+  "dependencies": {
+    "@nordcraft/core": "workspace:*",
+    "@nordcraft/ssr": "workspace:*",
+    "hono": "4.7.11"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "4.20250617.0",
+    "@nordcraft/runtime": "workspace:*",
+    "@types/node": "24.0.3",
+    "wrangler": "4.20.0"
+  }
+}

--- a/_assets_dev/src/index.ts
+++ b/_assets_dev/src/index.ts
@@ -1,0 +1,12 @@
+import { Hono } from 'hono'
+import { serveStatic } from 'hono/bun'
+
+const app = new Hono({ strict: false })
+
+// Serve static files from the dist directory
+app.get('*', serveStatic({ root: '../dist/' }))
+
+export default {
+  port: 1337,
+  fetch: app.fetch,
+}

--- a/_assets_dev/tsconfig.json
+++ b/_assets_dev/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    // Enable latest features
+    "lib": ["ESNext", "DOM.Iterable", "DOM"],
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleDetection": "force",
+    "jsx": "react-jsx",
+    "allowJs": true,
+
+    // Bundler mode
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+
+    // Best practices
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+
+    // Some stricter flags
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "types": []
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}

--- a/_assets_dev/wrangler.toml
+++ b/_assets_dev/wrangler.toml
@@ -1,0 +1,16 @@
+#:schema node_modules/wrangler/config-schema.json
+name = "toddle-worker-example"
+
+main = "dist/index.js"
+compatibility_date = "2025-02-05"
+
+rules = [
+  # Include all json files in the worker (should only be the actual project)
+  { type = "ESModule", globs = ["**/*.js"], fallthrough = true }
+]
+
+[observability.logs]
+enabled = true
+
+[assets]
+directory = "./assets"

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -4,5 +4,5 @@
     "strict": true,
     "allowJs": false
   },
-  "include": ["packages", "bin"]
+  "include": ["packages", "bin", "_assets_dev"]
 }


### PR DESCRIPTION
To allow easier internal testing of releases, it's useful to have a dev server that can serve the release assets. This means we don't have to wait for the full release process to test changes locally.