### PR TITLE
Add runtimeVersion to config

### DIFF
--- a/packages/ssr/src/ssr.types.ts
+++ b/packages/ssr/src/ssr.types.ts
@@ -26,8 +26,6 @@ export interface ToddleProject {
   emoji?: string | null
   type: 'app' | 'package'
   thumbnail?: { path: string } | null
-  // See https://github.com/nordcraftengine/nordcraft/releases
-  nordcraftVersion?: string
 }
 
 export interface ProjectFiles {
@@ -38,6 +36,8 @@ export interface ProjectFiles {
   formulas?: Record<string, PluginFormula<string>>
   routes?: Record<string, Route>
   config?: {
+    // See https://github.com/nordcraftengine/nordcraft/releases
+    nordcraftVersion?: string
     theme: OldTheme
     meta?: {
       icon?: { formula: Formula }

--- a/packages/ssr/src/ssr.types.ts
+++ b/packages/ssr/src/ssr.types.ts
@@ -37,7 +37,7 @@ export interface ProjectFiles {
   routes?: Record<string, Route>
   config?: {
     // See https://github.com/nordcraftengine/nordcraft/releases
-    nordcraftVersion?: string
+    runtimeVersion?: string
     theme: OldTheme
     meta?: {
       icon?: { formula: Formula }

--- a/packages/ssr/src/ssr.types.ts
+++ b/packages/ssr/src/ssr.types.ts
@@ -26,6 +26,8 @@ export interface ToddleProject {
   emoji?: string | null
   type: 'app' | 'package'
   thumbnail?: { path: string } | null
+  // See https://github.com/nordcraftengine/nordcraft/releases
+  nordcraftVersion?: string
 }
 
 export interface ProjectFiles {


### PR DESCRIPTION
This will be used for runtime versioning going forward. Adding it to `ProjectFiles.config` should mean this can be branch specific.