### PR TITLE
Send uncaught preview rendering errors to the editor

### DIFF
--- a/packages/runtime/src/debug/panicScreen.ts
+++ b/packages/runtime/src/debug/panicScreen.ts
@@ -1,0 +1,23 @@
+export const renderPanicScreen = (
+  title: string,
+  message: string,
+  isPage: boolean,
+) => `
+  <main style="background-color: blue; color: white; font-family: 'Courier New', monospace; font-weight: 100; display: flex; justify-content: flex-start; align-items: flex-start; margin: 0px; padding: 0px;">
+    <div style="display: flex; flex-direction: column; justify-content: space-between; align-items: flex-start; height: 100vh;">
+      <div style="display: flex; flex-direction: column; gap: 20px; padding: 80px;">
+        <div>
+          <h1 style="display: inline; font-size: 22px; background: white; color: blue; padding: 8px 16px;">${title}</h1>
+        </div>
+        <div>
+          <p style="font-size: 18px;">The ${isPage ? 'page' : 'component'} could not be rendered. Fix the issue and try again. Join our <a style="color:white" href="https://discord.gg/nordcraft" target="_blank">Discord</a> for help.</p>
+        </div>
+        <div>
+          <p style="font-size: 18px;">Error Message: ${message}</p>
+        </div>
+      </div>
+    </div>
+    <div style="position:fixed; pointer-events: none; width: 100vw; height: 100vh; background-image: linear-gradient(0deg, rgba(0,0,0,0) 25%, rgba(0,0,0,0.33) 25%, rgba(0,0,0,0.33) 50%, rgba(0,0,0,0) 50%, rgba(0,0,0,0) 75%, rgba(0,0,0,0.33) 75%, rgba(0,0,0,0.33) 100%); background-size: 4px 4px;"></div>
+    <div style="position:fixed; pointer-events: none; width: 100vw; height: 100vh; background-image: radial-gradient(ellipse at center, rgba(0,0,0,0) 50%, rgba(0,0,0,0.25) 100%);"></div>
+  </main>
+`

--- a/packages/runtime/src/debug/panicScreen.ts
+++ b/packages/runtime/src/debug/panicScreen.ts
@@ -1,23 +1,37 @@
-export const renderPanicScreen = (
-  title: string,
-  message: string,
-  isPage: boolean,
-) => `
-  <main style="background-color: blue; color: white; font-family: 'Courier New', monospace; font-weight: 100; display: flex; justify-content: flex-start; align-items: flex-start; margin: 0px; padding: 0px;">
-    <div style="display: flex; flex-direction: column; justify-content: space-between; align-items: flex-start; height: 100vh;">
-      <div style="display: flex; flex-direction: column; gap: 20px; padding: 80px;">
-        <div>
-          <h1 style="display: inline; font-size: 22px; background: white; color: blue; padding: 8px 16px;">${title}</h1>
+export const createPanicScreen = ({
+  name,
+  message,
+  isPage,
+  cause,
+}: {
+  name: string
+  message: string
+  isPage?: boolean
+  cause?: unknown
+}) => {
+  let content = getContent(name, message, isPage)
+
+  // Easter egg for RangeError
+  if (cause instanceof RangeError) {
+    for (let i = 0; i < 10; i++) {
+      content += `<div style="transform-origin: 15% 15%; scale: ${1 / (i * 0.225 + 1.225)}; font-size: ${22 / ((i * 0.6) ** 2 + 1)}px">${getContent(name, message, isPage)}</div>`
+    }
+  }
+
+  return document.createRange().createContextualFragment(`
+      <main style="background-color: blue; color: white; font-family: 'Courier New', monospace; font-weight: 100; display: flex; justify-content: flex-start; align-items: flex-start; margin: 0px; padding: 0px;">
+        <div style="display: flex; flex-direction: column; justify-content: space-between; align-items: flex-start; height: 100vh;">
+          <div style="display: flex; flex-direction: column; gap: 20px; padding: 80px; font-size: 22px;">
+            ${content}
+          </div>
         </div>
-        <div>
-          <p style="font-size: 18px;">The ${isPage ? 'page' : 'component'} could not be rendered. Fix the issue and try again. Join our <a style="color:white" href="https://discord.gg/nordcraft" target="_blank">Discord</a> for help.</p>
-        </div>
-        <div>
-          <p style="font-size: 18px;">Error Message: ${message}</p>
-        </div>
-      </div>
-    </div>
-    <div style="position:fixed; pointer-events: none; width: 100vw; height: 100vh; background-image: linear-gradient(0deg, rgba(0,0,0,0) 25%, rgba(0,0,0,0.33) 25%, rgba(0,0,0,0.33) 50%, rgba(0,0,0,0) 50%, rgba(0,0,0,0) 75%, rgba(0,0,0,0.33) 75%, rgba(0,0,0,0.33) 100%); background-size: 4px 4px;"></div>
-    <div style="position:fixed; pointer-events: none; width: 100vw; height: 100vh; background-image: radial-gradient(ellipse at center, rgba(0,0,0,0) 50%, rgba(0,0,0,0.25) 100%);"></div>
-  </main>
-`
+        <div style="position:fixed; pointer-events: none; width: 100vw; height: 100vh; background-image: linear-gradient(0deg, rgba(0,0,0,0) 25%, rgba(0,0,0,0.33) 25%, rgba(0,0,0,0.33) 50%, rgba(0,0,0,0) 50%, rgba(0,0,0,0) 75%, rgba(0,0,0,0.33) 75%, rgba(0,0,0,0.33) 100%); background-size: 4px 4px;"></div>
+        <div style="position:fixed; pointer-events: none; width: 100vw; height: 100vh; background-image: radial-gradient(ellipse at center, rgba(0,0,0,0) 50%, rgba(0,0,0,0.25) 100%);"></div>
+      </main>
+  `)
+}
+
+const getContent = (name: string, message: string, isPage?: boolean) => `
+  <h1 style="display: inline; font-size: 1em; background: white; color: blue; padding: 0.4em 0.8em;">${name}</h1>
+  <p style="font-size: 0.8em;">The ${isPage ? 'page' : 'component'} could not be rendered. Fix the issue and try again. Join our <a style="color:white" href="https://discord.gg/nordcraft" target="_blank">Discord</a> for help.</p>
+  <p style="font-size: 0.81em;">Error Message: ${message}</p>`

--- a/packages/runtime/src/debug/sendEditorToast.ts
+++ b/packages/runtime/src/debug/sendEditorToast.ts
@@ -1,0 +1,19 @@
+export function sendEditorToast(
+  title: string,
+  message: string,
+  {
+    type = 'neutral',
+  }: {
+    type?: 'neutral' | 'warning' | 'critical'
+  },
+) {
+  window.parent?.postMessage(
+    {
+      type: 'emitToast',
+      toastType: type,
+      title,
+      message,
+    },
+    '*',
+  )
+}

--- a/packages/runtime/src/editor-preview.main.ts
+++ b/packages/runtime/src/editor-preview.main.ts
@@ -1430,9 +1430,9 @@ export const createRoot = (
           if (error instanceof RangeError) {
             // RangeError is unrecoverable
             panic = true
-            name = 'Maximum call stack size exceeded'
+            name = 'Infinite loop detected'
             message =
-              'RangeError: Remove any circular dependencies or recursive calls in components, formulas or actions without an exit case.'
+              'RangeError (Maximum call stack size exceeded): Remove any circular dependencies or recursive calls. This is most likely caused by components, formulas or actions using themselves without an exit case.'
           }
 
           // Send a toast to the editor with the error


### PR DESCRIPTION
This will let us show a toast when a user is using a circular formula with no exit condition or a recursive component. Unlike some other frameworks, I'm just using the browsers own maximum call stack error instead of a custom solution of keeping track of the render depth. Upside is less logic and a deeper max call stack. Downside is that we cannot explicitly say which component(s) or formula(s) are involved in the infinite depth. We could store a component stack in a separate global variable though 🤔 

This is implemented generically and can be used in the future for any info messages from the runtime to the editor.

To test, just add a component to itself or call a formula/action in themselves.