### PR TITLE
Add issue rule for invalid interactive content

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nordcraft",
   "type": "module",
   "license": "Apache-2.0",
-  "version": "1.0.34",
+  "version": "1.0.35",
   "homepage": "https://github.com/nordcraftengine/nordcraft",
   "private": "false",
   "workspaces": [

--- a/packages/runtime/src/components/createNode.ts
+++ b/packages/runtime/src/components/createNode.ts
@@ -121,14 +121,14 @@ export function createNode({
 
         if (!parentElement || ctx.root.contains(parentElement) === false) {
           console.error(
-            `Conditional: Parent element does not exist for "${path}" This is likely due to the DOM being modified outside of toddle.`,
+            `Conditional: Parent element does not exist for "${path}" This is likely due to the DOM being modified outside of Nordcraft.`,
           )
           return
         }
 
         if (parentElement.querySelector(`[data-id="${path}"]`)) {
           console.warn(
-            `Conditional: Element with data-id="${path}" already exists. This is likely due to the DOM being modified outside of toddle`,
+            `Conditional: Element with data-id="${path}" already exists. This is likely due to the DOM being modified outside of Nordcraft`,
           )
           return
         }
@@ -315,7 +315,7 @@ export function createNode({
 
         if (!parentElement || ctx.root.contains(parentElement) === false) {
           console.error(
-            `Repeat: Parent element does not exist for ${path}. This is likely due to the DOM being modified outside of toddle.`,
+            `Repeat: Parent element does not exist for ${path}. This is likely due to the DOM being modified outside of Nordcraft.`,
           )
           return
         }

--- a/packages/search/src/memos/getAllCustomPropertiesBySyntax.ts
+++ b/packages/search/src/memos/getAllCustomPropertiesBySyntax.ts
@@ -1,8 +1,9 @@
 import type { CssSyntaxNode } from '@nordcraft/core/dist/styling/customProperty'
 import type { ProjectFiles } from '@nordcraft/ssr/dist/ssr.types'
+import type { MemoFn } from '../types'
 
 export const getAllCustomPropertiesBySyntax = (
-  memo: <T>(key: string, fn: () => T) => T,
+  memo: MemoFn,
   {
     files,
   }: {

--- a/packages/search/src/problems.worker.ts
+++ b/packages/search/src/problems.worker.ts
@@ -126,7 +126,7 @@ const RULES = [
   duplicateRouteRule,
   duplicateUrlParameterRule,
   duplicateWorkflowParameterRule,
-  elementWithoutInteractiveContentRule({}),
+  elementWithoutInteractiveContentRule,
   imageWithoutDimensionRule,
   legacyActionRule,
   legacyApiRule,

--- a/packages/search/src/problems.worker.ts
+++ b/packages/search/src/problems.worker.ts
@@ -19,6 +19,7 @@ import { createRequiredDirectChildRule } from './rules/dom/createRequiredDirectC
 import { createRequiredDirectParentRule } from './rules/dom/createRequiredDirectParentRule'
 import { createRequiredElementAttributeRule } from './rules/dom/createRequiredElementAttributeRule'
 import { createRequiredMetaTagRule } from './rules/dom/createRequiredMetaTagRule'
+import { elementWithoutInteractiveContentRule } from './rules/dom/elementWithoutInteractiveContentRule'
 import { imageWithoutDimensionRule } from './rules/dom/imageWithoutDimensionRule'
 import { nonEmptyVoidElementRule } from './rules/dom/nonEmptyVoidElementRule'
 import { duplicateRouteRule } from './rules/duplicateRouteRule'
@@ -125,6 +126,7 @@ const RULES = [
   duplicateRouteRule,
   duplicateUrlParameterRule,
   duplicateWorkflowParameterRule,
+  elementWithoutInteractiveContentRule({}),
   imageWithoutDimensionRule,
   legacyActionRule,
   legacyApiRule,

--- a/packages/search/src/rules/dom/elementWithoutInteractiveContentRule.test.ts
+++ b/packages/search/src/rules/dom/elementWithoutInteractiveContentRule.test.ts
@@ -48,7 +48,7 @@ describe('elementWithoutInteractiveContentRule', () => {
             },
           },
         },
-        rules: [elementWithoutInteractiveContentRule({})],
+        rules: [elementWithoutInteractiveContentRule],
       }),
     )
     expect(problems).toHaveLength(1)
@@ -103,7 +103,7 @@ describe('elementWithoutInteractiveContentRule', () => {
             },
           },
         },
-        rules: [elementWithoutInteractiveContentRule({})],
+        rules: [elementWithoutInteractiveContentRule],
       }),
     )
     expect(problems).toHaveLength(1)
@@ -158,7 +158,7 @@ describe('elementWithoutInteractiveContentRule', () => {
             },
           },
         },
-        rules: [elementWithoutInteractiveContentRule({})],
+        rules: [elementWithoutInteractiveContentRule],
       }),
     )
     expect(problems).toHaveLength(1)
@@ -213,7 +213,7 @@ describe('elementWithoutInteractiveContentRule', () => {
             },
           },
         },
-        rules: [elementWithoutInteractiveContentRule({})],
+        rules: [elementWithoutInteractiveContentRule],
       }),
     )
     expect(problems).toHaveLength(0)
@@ -262,7 +262,7 @@ describe('elementWithoutInteractiveContentRule', () => {
             },
           },
         },
-        rules: [elementWithoutInteractiveContentRule({})],
+        rules: [elementWithoutInteractiveContentRule],
       }),
     )
     expect(problems).toHaveLength(0)
@@ -337,7 +337,7 @@ describe('elementWithoutInteractiveContentRule', () => {
             },
           },
         },
-        rules: [elementWithoutInteractiveContentRule({})],
+        rules: [elementWithoutInteractiveContentRule],
       }),
     )
     expect(problems).toHaveLength(1)
@@ -392,7 +392,7 @@ describe('elementWithoutInteractiveContentRule', () => {
             },
           },
         },
-        rules: [elementWithoutInteractiveContentRule({})],
+        rules: [elementWithoutInteractiveContentRule],
       }),
     )
 

--- a/packages/search/src/rules/dom/elementWithoutInteractiveContentRule.test.ts
+++ b/packages/search/src/rules/dom/elementWithoutInteractiveContentRule.test.ts
@@ -1,0 +1,401 @@
+import { valueFormula } from '@nordcraft/core/dist/formula/formulaUtils'
+import { describe, expect, test } from 'bun:test'
+import { searchProject } from '../../searchProject'
+import { elementWithoutInteractiveContentRule } from './elementWithoutInteractiveContentRule'
+
+describe('elementWithoutInteractiveContentRule', () => {
+  test('should detect invalid button in button element', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          formulas: {},
+          components: {
+            test: {
+              name: 'test',
+              nodes: {
+                root: {
+                  type: 'element',
+                  attrs: {},
+                  classes: {},
+                  events: {},
+                  tag: 'button',
+                  children: ['child1'],
+                  style: {},
+                },
+                child1: {
+                  type: 'element',
+                  attrs: {},
+                  classes: {},
+                  events: {},
+                  tag: 'div',
+                  children: ['child2'],
+                  style: {},
+                },
+                child2: {
+                  type: 'element',
+                  attrs: {},
+                  classes: {},
+                  events: {},
+                  tag: 'button',
+                  children: [],
+                  style: {},
+                },
+              },
+              formulas: {},
+              apis: {},
+              attributes: {},
+              variables: {},
+            },
+          },
+        },
+        rules: [elementWithoutInteractiveContentRule({})],
+      }),
+    )
+    expect(problems).toHaveLength(1)
+    expect(problems[0].code).toBe('invalid element child')
+    expect(problems[0].path).toEqual(['components', 'test', 'nodes', 'root'])
+    expect(problems[0].details).toEqual({
+      parentTag: 'button',
+      invalidChild: { tag: 'button' },
+    })
+  })
+  test('should detect invalid label in button element', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          formulas: {},
+          components: {
+            test: {
+              name: 'test',
+              nodes: {
+                root: {
+                  type: 'element',
+                  attrs: {},
+                  classes: {},
+                  events: {},
+                  tag: 'button',
+                  children: ['child1'],
+                  style: {},
+                },
+                child1: {
+                  type: 'element',
+                  attrs: {},
+                  classes: {},
+                  events: {},
+                  tag: 'div',
+                  children: ['child2'],
+                  style: {},
+                },
+                child2: {
+                  type: 'element',
+                  attrs: {},
+                  classes: {},
+                  events: {},
+                  tag: 'label',
+                  children: [],
+                  style: {},
+                },
+              },
+              formulas: {},
+              apis: {},
+              attributes: {},
+              variables: {},
+            },
+          },
+        },
+        rules: [elementWithoutInteractiveContentRule({})],
+      }),
+    )
+    expect(problems).toHaveLength(1)
+    expect(problems[0].code).toBe('invalid element child')
+    expect(problems[0].path).toEqual(['components', 'test', 'nodes', 'root'])
+    expect(problems[0].details).toEqual({
+      parentTag: 'button',
+      invalidChild: { tag: 'label' },
+    })
+  })
+  test('should detect invalid element with attribute requirement', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          formulas: {},
+          components: {
+            test: {
+              name: 'test',
+              nodes: {
+                root: {
+                  type: 'element',
+                  attrs: {},
+                  classes: {},
+                  events: {},
+                  tag: 'button',
+                  children: ['child1'],
+                  style: {},
+                },
+                child1: {
+                  type: 'element',
+                  attrs: {},
+                  classes: {},
+                  events: {},
+                  tag: 'div',
+                  children: ['child2'],
+                  style: {},
+                },
+                child2: {
+                  type: 'element',
+                  attrs: { href: valueFormula('https://example.com') },
+                  classes: {},
+                  events: {},
+                  tag: 'a',
+                  children: [],
+                  style: {},
+                },
+              },
+              formulas: {},
+              apis: {},
+              attributes: {},
+              variables: {},
+            },
+          },
+        },
+        rules: [elementWithoutInteractiveContentRule({})],
+      }),
+    )
+    expect(problems).toHaveLength(1)
+    expect(problems[0].code).toBe('invalid element child')
+    expect(problems[0].path).toEqual(['components', 'test', 'nodes', 'root'])
+    expect(problems[0].details).toEqual({
+      parentTag: 'button',
+      invalidChild: { tag: 'a', whenAttributeIsPresent: 'href' },
+    })
+  })
+  test('should allow element children when attribute requirement is not met', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          formulas: {},
+          components: {
+            test: {
+              name: 'test',
+              nodes: {
+                root: {
+                  type: 'element',
+                  attrs: {},
+                  classes: {},
+                  events: {},
+                  tag: 'button',
+                  children: ['child1'],
+                  style: {},
+                },
+                child1: {
+                  type: 'element',
+                  attrs: {},
+                  classes: {},
+                  events: {},
+                  tag: 'div',
+                  children: ['child2'],
+                  style: {},
+                },
+                child2: {
+                  type: 'element',
+                  attrs: {},
+                  classes: {},
+                  events: {},
+                  tag: 'a',
+                  children: [],
+                  style: {},
+                },
+              },
+              formulas: {},
+              apis: {},
+              attributes: {},
+              variables: {},
+            },
+          },
+        },
+        rules: [elementWithoutInteractiveContentRule({})],
+      }),
+    )
+    expect(problems).toHaveLength(0)
+  })
+  test('should detect invalid children when negative attribute requirement is met', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          formulas: {},
+          components: {
+            test: {
+              name: 'test',
+              nodes: {
+                root: {
+                  type: 'element',
+                  attrs: {},
+                  classes: {},
+                  events: {},
+                  tag: 'button',
+                  children: ['child1'],
+                  style: {},
+                },
+                child1: {
+                  type: 'element',
+                  attrs: {},
+                  classes: {},
+                  events: {},
+                  tag: 'div',
+                  children: ['child2'],
+                  style: {},
+                },
+                child2: {
+                  type: 'element',
+                  attrs: { type: valueFormula('text') },
+                  classes: {},
+                  events: {},
+                  tag: 'input',
+                  children: [],
+                  style: {},
+                },
+              },
+              formulas: {},
+              apis: {},
+              attributes: {},
+              variables: {},
+            },
+          },
+        },
+        rules: [elementWithoutInteractiveContentRule({})],
+      }),
+    )
+    expect(problems).toHaveLength(0)
+  })
+  test('should detect invalid label in button element in nested component', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          formulas: {},
+          components: {
+            test: {
+              name: 'test',
+              nodes: {
+                root: {
+                  type: 'element',
+                  attrs: {},
+                  classes: {},
+                  events: {},
+                  tag: 'button',
+                  children: ['child1'],
+                  style: {},
+                },
+                child1: {
+                  type: 'component',
+                  attrs: {},
+                  name: 'buttonComponent',
+                  events: {},
+                  children: [],
+                  style: {},
+                },
+              },
+              formulas: {},
+              apis: {},
+              attributes: {},
+              variables: {},
+            },
+            buttonComponent: {
+              name: 'buttonComponent',
+              nodes: {
+                root: {
+                  type: 'element',
+                  attrs: {},
+                  classes: {},
+                  events: {},
+                  tag: 'div',
+                  children: ['child1'],
+                  style: {},
+                },
+                child1: {
+                  type: 'element',
+                  attrs: {},
+                  classes: {},
+                  events: {},
+                  tag: 'div',
+                  children: ['child2'],
+                  style: {},
+                },
+                child2: {
+                  type: 'element',
+                  attrs: {},
+                  classes: {},
+                  events: {},
+                  tag: 'label',
+                  children: [],
+                  style: {},
+                },
+              },
+              formulas: {},
+              apis: {},
+              attributes: {},
+              variables: {},
+            },
+          },
+        },
+        rules: [elementWithoutInteractiveContentRule({})],
+      }),
+    )
+    expect(problems).toHaveLength(1)
+    expect(problems[0].code).toBe('invalid element child')
+    expect(problems[0].path).toEqual(['components', 'test', 'nodes', 'root'])
+    expect(problems[0].details).toEqual({
+      parentTag: 'button',
+      invalidChild: { tag: 'label' },
+    })
+  })
+  test('should not detect valid element children', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          formulas: {},
+          components: {
+            test: {
+              name: 'test',
+              nodes: {
+                root: {
+                  type: 'element',
+                  attrs: {},
+                  classes: {},
+                  events: {},
+                  tag: 'button',
+                  children: ['child1', 'child2'],
+                  style: {},
+                },
+                child1: {
+                  type: 'element',
+                  attrs: {},
+                  classes: {},
+                  events: {},
+                  tag: 'p',
+                  children: [],
+                  style: {},
+                },
+                child2: {
+                  type: 'element',
+                  attrs: {},
+                  classes: {},
+                  events: {},
+                  tag: 'p',
+                  children: [],
+                  style: {},
+                },
+              },
+              formulas: {},
+              apis: {},
+              attributes: {},
+              variables: {},
+            },
+          },
+        },
+        rules: [elementWithoutInteractiveContentRule({})],
+      }),
+    )
+
+    expect(problems).toHaveLength(0)
+  })
+})

--- a/packages/search/src/rules/dom/elementWithoutInteractiveContentRule.ts
+++ b/packages/search/src/rules/dom/elementWithoutInteractiveContentRule.ts
@@ -1,7 +1,7 @@
 import type { Component } from '@nordcraft/core/dist/component/component.types'
 import type { ToddleComponent } from '@nordcraft/core/dist/component/ToddleComponent'
 import { isDefined } from '@nordcraft/core/dist/utils/util'
-import type { Level, Rule } from '../../types'
+import type { Rule } from '../../types'
 import {
   interactiveContentElementDefinition,
   type InteractiveContent,
@@ -9,79 +9,72 @@ import {
 
 const ELEMENTS_WITHOUT_INTERACTIVE_CONTENT = ['button', 'a']
 
-export function elementWithoutInteractiveContentRule({
-  level = 'warning',
-}: {
-  level?: Level
-}): Rule<{
+export const elementWithoutInteractiveContentRule: Rule<{
   parentTag: string
   invalidChild: InteractiveContent
-}> {
-  return {
-    code: 'invalid element child',
-    level,
-    category: 'Accessibility',
-    visit: (report, args) => {
-      if (args.nodeType !== 'component-node') {
-        return
-      }
-      const { value, component, path, files } = args
-      if (
-        value.type !== 'element' ||
-        !ELEMENTS_WITHOUT_INTERACTIVE_CONTENT.includes(value.tag)
-      ) {
-        return
-      }
-      // TODO: Consider memoizing this function to avoid repeated searches
-      const searchChildren = (
-        container: ToddleComponent<Function> | Component,
-        children: string[],
-        results: Array<InteractiveContent> = [],
-      ): Array<InteractiveContent> => {
-        return children.reduce((acc, childId) => {
-          const child = container.nodes[childId]
-          if (!isDefined(child) || child.type === 'text') {
-            return acc
+}> = {
+  code: 'invalid element child',
+  level: 'error',
+  category: 'Accessibility',
+  visit: (report, args) => {
+    if (args.nodeType !== 'component-node') {
+      return
+    }
+    const { value, component, path, files } = args
+    if (
+      value.type !== 'element' ||
+      !ELEMENTS_WITHOUT_INTERACTIVE_CONTENT.includes(value.tag)
+    ) {
+      return
+    }
+    // TODO: Consider memoizing this function to avoid repeated searches
+    const searchChildren = (
+      container: ToddleComponent<Function> | Component,
+      children: string[],
+      results: Array<InteractiveContent> = [],
+    ): Array<InteractiveContent> => {
+      return children.reduce((acc, childId) => {
+        const child = container.nodes[childId]
+        if (!isDefined(child) || child.type === 'text') {
+          return acc
+        }
+        if (child.type === 'element') {
+          // Check if the child element is an interactive content element
+          const interactiveElement = interactiveContentElementDefinition(child)
+          if (interactiveElement) {
+            // TODO: consider visiting this element's children instead of returning early
+            return [...acc, interactiveElement]
           }
-          if (child.type === 'element') {
-            // Check if the child element is an interactive content element
-            const interactiveElement =
-              interactiveContentElementDefinition(child)
-            if (interactiveElement) {
-              // TODO: consider visiting this element's children instead of returning early
-              return [...acc, interactiveElement]
-            }
+        }
+        const allResults = [...acc]
+        if (child.type === 'component') {
+          const component = child.package
+            ? files.packages?.[child.package]?.components?.[child.name]
+            : files.components?.[child.name]
+          if (!component) {
+            return results
           }
-          const allResults = [...acc]
-          if (child.type === 'component') {
-            const component = child.package
-              ? files.packages?.[child.package]?.components?.[child.name]
-              : files.components?.[child.name]
-            if (!component) {
-              return results
-            }
-            // Search children in the component's own nodes
-            allResults.push(
-              ...searchChildren(
-                component,
-                component.nodes['root']?.children ?? [],
-                acc,
-              ),
-            )
-          }
-          // Search children in slot/component/element:
-          return searchChildren(container, child.children, allResults)
-        }, results)
-      }
-      const childTags = searchChildren(component, value.children)
-      if (childTags.length > 0) {
-        childTags.forEach((ic) =>
-          report(path, {
-            parentTag: value.tag,
-            invalidChild: ic,
-          }),
-        )
-      }
-    },
-  }
+          // Search children in the component's own nodes
+          allResults.push(
+            ...searchChildren(
+              component,
+              component.nodes['root']?.children ?? [],
+              acc,
+            ),
+          )
+        }
+        // Search children in slot/component/element:
+        return searchChildren(container, child.children, allResults)
+      }, results)
+    }
+    const childTags = searchChildren(component, value.children)
+    if (childTags.length > 0) {
+      childTags.forEach((ic) =>
+        report(path, {
+          parentTag: value.tag,
+          invalidChild: ic,
+        }),
+      )
+    }
+  },
 }

--- a/packages/search/src/rules/dom/elementWithoutInteractiveContentRule.ts
+++ b/packages/search/src/rules/dom/elementWithoutInteractiveContentRule.ts
@@ -1,0 +1,87 @@
+import type { Component } from '@nordcraft/core/dist/component/component.types'
+import type { ToddleComponent } from '@nordcraft/core/dist/component/ToddleComponent'
+import { isDefined } from '@nordcraft/core/dist/utils/util'
+import type { Level, Rule } from '../../types'
+import {
+  interactiveContentElementDefinition,
+  type InteractiveContent,
+} from '../../util/helpers'
+
+const ELEMENTS_WITHOUT_INTERACTIVE_CONTENT = ['button', 'a']
+
+export function elementWithoutInteractiveContentRule({
+  level = 'warning',
+}: {
+  level?: Level
+}): Rule<{
+  parentTag: string
+  invalidChild: InteractiveContent
+}> {
+  return {
+    code: 'invalid element child',
+    level,
+    category: 'Accessibility',
+    visit: (report, args) => {
+      if (args.nodeType !== 'component-node') {
+        return
+      }
+      const { value, component, path, files } = args
+      if (
+        value.type !== 'element' ||
+        !ELEMENTS_WITHOUT_INTERACTIVE_CONTENT.includes(value.tag)
+      ) {
+        return
+      }
+      // TODO: Consider memoizing this function to avoid repeated searches
+      const searchChildren = (
+        container: ToddleComponent<Function> | Component,
+        children: string[],
+        results: Array<InteractiveContent> = [],
+      ): Array<InteractiveContent> => {
+        return children.reduce((acc, childId) => {
+          const child = container.nodes[childId]
+          if (!isDefined(child) || child.type === 'text') {
+            return acc
+          }
+          if (child.type === 'element') {
+            // Check if the child element is an interactive content element
+            const interactiveElement =
+              interactiveContentElementDefinition(child)
+            if (interactiveElement) {
+              // TODO: consider visiting this element's children instead of returning early
+              return [...acc, interactiveElement]
+            }
+          }
+          const allResults = [...acc]
+          if (child.type === 'component') {
+            const component = child.package
+              ? files.packages?.[child.package]?.components?.[child.name]
+              : files.components?.[child.name]
+            if (!component) {
+              return results
+            }
+            // Search children in the component's own nodes
+            allResults.push(
+              ...searchChildren(
+                component,
+                component.nodes['root']?.children ?? [],
+                acc,
+              ),
+            )
+          }
+          // Search children in slot/component/element:
+          return searchChildren(container, child.children, allResults)
+        }, results)
+      }
+      const childTags = searchChildren(component, value.children)
+      if (childTags.length > 0) {
+        childTags.forEach((ic) =>
+          report(path, {
+            parentTag: value.tag,
+            invalidChild: ic,
+          }),
+        )
+      }
+    },
+  }
+}

--- a/packages/search/src/rules/dom/elementWithoutInteractiveContentRule.ts
+++ b/packages/search/src/rules/dom/elementWithoutInteractiveContentRule.ts
@@ -14,7 +14,7 @@ export const elementWithoutInteractiveContentRule: Rule<{
   invalidChild: InteractiveContent
 }> = {
   code: 'invalid element child',
-  level: 'error',
+  level: 'warning',
   category: 'Accessibility',
   visit: (report, args) => {
     if (args.nodeType !== 'component-node') {

--- a/packages/search/src/searchProject.ts
+++ b/packages/search/src/searchProject.ts
@@ -160,6 +160,7 @@ function* visitNode(
   } & NodeType,
   state: ApplicationState | undefined,
 ): Generator<Result> {
+  performance.mark(`visitNode-${args.path.join('/')}`)
   const { rules, pathsToVisit, ...data } = args
   const { files, value, path, memo, nodeType } = data
   if (!shouldSearchPath(data.path, pathsToVisit)) {
@@ -168,6 +169,7 @@ function* visitNode(
 
   const results: Result[] = []
   for (const rule of rules) {
+    performance.mark(`rule-${rule.code}`)
     rule.visit(
       (path, details) => {
         results.push({

--- a/packages/search/src/types.d.ts
+++ b/packages/search/src/types.d.ts
@@ -136,6 +136,8 @@ export interface ApplicationState {
   projectDetails?: ToddleProject
 }
 
+type MemoFn = <T>(key: string, fn: () => T) => T
+
 type Base = {
   files: Omit<ProjectFiles, 'config'> & Partial<Pick<ProjectFiles, 'config'>>
   /**
@@ -150,7 +152,7 @@ type Base = {
    * @param fn A function that returns the value to be memoized. This function is only called if the value is not already in the cache already.
    * @returns The value of the memoized function.
    */
-  memo: <T>(key: string, fn: () => T) => T
+  memo: MemoFn
 }
 
 type ProjectFormulaNode = {

--- a/packages/search/src/types.d.ts
+++ b/packages/search/src/types.d.ts
@@ -30,6 +30,7 @@ type Code =
   | 'duplicate route'
   | 'invalid api parser mode'
   | 'invalid api proxy body setting'
+  | 'invalid element child'
   | 'legacy action'
   | 'legacy api'
   | 'legacy formula'

--- a/packages/search/src/util/helpers.ts
+++ b/packages/search/src/util/helpers.ts
@@ -95,13 +95,10 @@ export const interactiveContentElementDefinition = (
     }
     if ('whenAttributeIsNot' in ic) {
       const attributeFormula = element.attrs[ic.whenAttributeIsNot.attribute]
-      if (
-        !attributeFormula ||
-        attributeFormula.type !== 'value' ||
-        attributeFormula.value !== ic.whenAttributeIsNot.value
-      ) {
-        return false
-      }
+      return (
+        attributeFormula?.type === 'value' &&
+        attributeFormula.value === ic.whenAttributeIsNot.value
+      )
     }
     return true
   })


### PR DESCRIPTION
Add a warning when a button or `<a>` element has interactive content as a child element. This is not valid and should be avoided. There are edge cases when using slots and conditionals that might lead to more warnings than necessary, but generally this rule should help improve correctness of users' application structure.