### PR TITLE
Allow all HTTP methods for proxy requests

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -42,7 +42,7 @@ app.use(routesLoader, loadProjectInfo)
 app.get('/.toddle/custom-element/:filename{.+.js}', customElement)
 
 // Load a route if it matches the URL
-app.get('/*', routeHandler)
+app.all('/*', routeHandler)
 
 // Load default resource endpoints
 app.get('/sitemap.xml', sitemap)

--- a/packages/backend/src/preview.index.ts
+++ b/packages/backend/src/preview.index.ts
@@ -74,7 +74,7 @@ app.get('/.toddle/stylesheet/:pageName{.+.css}', stylesheetHandler)
 app.get('/.toddle/custom-code/:pageName{.+.js}', customCode)
 
 // Load a route if it matches the URL
-app.get('/*', routeHandler)
+app.all('/*', routeHandler)
 
 // Load default resource endpoints
 app.get('/sitemap.xml', sitemap)


### PR DESCRIPTION
Support other HTTP methods than `GET` for requests to [proxies](https://docs.nordcraft.com/pages/proxies). This is useful if you want to proxy a `POST` request, to a GraphQL API for instance, or for certain tracking services that you need to send through the same origin as the web page your user is visiting.