### PR TITLE
Stop supporting autofix of BOOLEAN formula

### DIFF
--- a/packages/search/src/rules/formulas/legacyFormulaRule.ts
+++ b/packages/search/src/rules/formulas/legacyFormulaRule.ts
@@ -25,8 +25,10 @@ export const legacyFormulaRule: Rule<{
     report(
       data.path,
       { name: data.value.name },
-      // The TYPE formula cannot be autofixed since the types have changed between the 2 implementations
-      data.value.name !== 'TYPE' ? ['replace-legacy-formula'] : undefined,
+      // The TYPE and BOOLEAN formulas cannot be autofixed since the logic has changed between the 2 implementations
+      data.value.name !== 'TYPE' && data.value.name !== 'BOOLEAN'
+        ? ['replace-legacy-formula']
+        : undefined,
     )
   },
   fixes: {
@@ -371,14 +373,6 @@ export const legacyFormulaRule: Rule<{
             display_name: 'Append',
           }
           return set(data.files, data.path, newAppendFormula)
-        }
-        case 'BOOLEAN': {
-          const newBooleanFormula: FunctionOperation = {
-            ...data.value,
-            name: '@toddle/boolean',
-            display_name: 'Boolean',
-          }
-          return set(data.files, data.path, newBooleanFormula)
         }
         case 'CLAMP': {
           const newClampFormula: FunctionOperation = {


### PR DESCRIPTION
The implementation of the `BOOLEAN` formula was `Boolean(value)` which doesn't match the new formula's implementation (`value !== false && value !== undefined && value !== null`). Therefore, we cannot autofix it safely.