### PR TITLE
Allow autofixing legacy actions

### DIFF
--- a/packages/core/src/component/component.types.ts
+++ b/packages/core/src/component/component.types.ts
@@ -289,14 +289,22 @@ export interface EventModel {
   actions: ActionModel[]
 }
 
+export interface CustomActionArgument {
+  name: string
+  formula: Formula
+  type?: any
+  description?: string
+}
+
 export interface CustomActionModel {
   // Some legacy custom actions use an undefined type
   type?: 'Custom'
   package?: string
   name: string
   description?: string
+  group?: string
   data?: string | number | boolean | Formula
-  arguments?: { name: string; formula: Formula }[]
+  arguments?: CustomActionArgument[]
   events?: Record<string, { actions: ActionModel[] }>
   version?: 2 | never
   label?: string
@@ -306,7 +314,7 @@ export interface SwitchActionModel {
   type: 'Switch'
   data?: string | number | boolean | Formula
   cases: Array<{
-    condition: Formula
+    condition: Formula | null
     actions: ActionModel[]
   }>
   default: { actions: ActionModel[] }

--- a/packages/core/src/formula/formula.ts
+++ b/packages/core/src/formula/formula.ts
@@ -28,6 +28,7 @@ export interface FunctionArgument {
   name?: string
   isFunction?: boolean
   formula: Formula
+  type?: any
 }
 
 export interface FunctionOperation extends BaseOperation {

--- a/packages/search/src/rules/actions/legacyActionRule.test.ts
+++ b/packages/search/src/rules/actions/legacyActionRule.test.ts
@@ -1,8 +1,14 @@
+import type {
+  ActionModel,
+  ElementNodeModel,
+} from '@nordcraft/core/dist/component/component.types'
+import type { ProjectFiles } from '@nordcraft/ssr/dist/ssr.types'
 import { describe, expect, test } from 'bun:test'
+import { fixProject } from '../../fixProject'
 import { searchProject } from '../../searchProject'
 import { legacyActionRule } from './legacyActionRule'
 
-describe('legacyAction', () => {
+describe('find legacyActions', () => {
   test('should detect legacy actions used in components', () => {
     const problems = Array.from(
       searchProject({
@@ -88,5 +94,180 @@ describe('legacyAction', () => {
       }),
     )
     expect(problems).toHaveLength(0)
+  })
+})
+
+describe('fix legacyActions', () => {
+  test('should replace the If action with a Switch action', () => {
+    const projectFiles: ProjectFiles = {
+      formulas: {},
+      components: {
+        apiComponent: {
+          name: 'test',
+          nodes: {
+            root: {
+              tag: 'p',
+              type: 'element',
+              attrs: {},
+              style: {},
+              events: {
+                click: {
+                  trigger: 'click',
+                  actions: [
+                    {
+                      name: 'If',
+                      events: {
+                        true: {
+                          actions: [
+                            {
+                              name: '@toddle/logToConsole',
+                              arguments: [
+                                {
+                                  name: 'Label',
+                                  description: 'A label for the message.',
+                                  formula: { type: 'value', value: '' },
+                                },
+                                {
+                                  name: 'Data',
+                                  type: { type: 'Any' },
+                                  description:
+                                    'The data you want to log to the console.',
+                                  formula: {
+                                    type: 'value',
+                                    value: '<Data>',
+                                  },
+                                },
+                              ],
+                              label: 'Log to console',
+                              group: 'debugging',
+                              description:
+                                'Log a message to the browser console.',
+                            },
+                          ],
+                        },
+                        false: {
+                          actions: [
+                            {
+                              name: '@toddle/logToConsole',
+                              arguments: [
+                                {
+                                  name: 'Label',
+                                  description: 'A label for the message.',
+                                  formula: { type: 'value', value: '' },
+                                },
+                                {
+                                  name: 'Data',
+                                  type: { type: 'Any' },
+                                  description:
+                                    'The data you want to log to the console.',
+                                  formula: {
+                                    type: 'value',
+                                    value: '<Data>',
+                                  },
+                                },
+                              ],
+                              label: 'Log to console',
+                              group: 'debugging',
+                              description:
+                                'Log a message to the browser console.',
+                            },
+                          ],
+                        },
+                      },
+                      arguments: [
+                        {
+                          name: 'Condition',
+                          formula: { type: 'value', value: true },
+                        },
+                      ],
+                    },
+                  ],
+                },
+              },
+              classes: {},
+              children: [],
+            },
+          },
+          formulas: {},
+          apis: {},
+          attributes: {},
+          variables: {},
+        },
+      },
+    }
+    const fixedProject = fixProject({
+      files: projectFiles,
+      rule: legacyActionRule,
+      fixType: 'replace-legacy-action',
+    })
+    const fixedAction = (
+      fixedProject.components['apiComponent']?.nodes['root'] as ElementNodeModel
+    ).events['click'].actions[0]
+    expect(fixedAction).toBeDefined()
+    expect((fixedAction as any).type).toBe('Switch')
+    expect((fixedAction as any).cases).toHaveLength(1)
+    expect((fixedAction as any).cases[0].actions).toHaveLength(1)
+    expect((fixedAction as any).default.actions).toHaveLength(1)
+  })
+  test('should replace the TriggerEvent action with the builtin action', () => {
+    const legacyAction: ActionModel = {
+      name: 'TriggerEvent',
+      arguments: [
+        {
+          name: 'name',
+          formula: { type: 'value', value: 'sdfsdf' },
+        },
+        {
+          name: 'data',
+          formula: { type: 'value', value: 'test' },
+        },
+      ],
+    }
+    const projectFiles: ProjectFiles = {
+      formulas: {},
+      components: {
+        apiComponent: {
+          name: 'test',
+          nodes: {
+            root: {
+              tag: 'p',
+              type: 'element',
+              attrs: {},
+              style: {},
+              events: {
+                click: {
+                  trigger: 'click',
+                  actions: [legacyAction],
+                },
+              },
+              classes: {},
+              children: [],
+            },
+          },
+          formulas: {},
+          apis: {},
+          attributes: {},
+          variables: {},
+        },
+      },
+    }
+    const fixedProject = fixProject({
+      files: projectFiles,
+      rule: legacyActionRule,
+      fixType: 'replace-legacy-action',
+    })
+    const fixedAction = (
+      fixedProject.components['apiComponent']?.nodes['root'] as ElementNodeModel
+    ).events['click'].actions[0]
+    expect(fixedAction).toBeDefined()
+    expect((fixedAction as any).type).toBe('TriggerEvent')
+    // the name of the event should be copied over from the arguments
+    expect((fixedAction as any).event).toEqual(
+      (legacyAction.arguments?.[0].formula as any).value,
+    )
+    // the data of the event should be copied over from the arguments
+    expect((fixedAction as any).data).toEqual(
+      legacyAction.arguments?.[1].formula,
+    )
   })
 })

--- a/packages/search/src/rules/actions/legacyActionRule.test.ts
+++ b/packages/search/src/rules/actions/legacyActionRule.test.ts
@@ -99,6 +99,69 @@ describe('find legacyActions', () => {
 
 describe('fix legacyActions', () => {
   test('should replace the If action with a Switch action', () => {
+    const legacyIfAction: ActionModel = {
+      name: 'If',
+      events: {
+        true: {
+          actions: [
+            {
+              name: '@toddle/logToConsole',
+              arguments: [
+                {
+                  name: 'Label',
+                  description: 'A label for the message.',
+                  formula: { type: 'value', value: '' },
+                },
+                {
+                  name: 'Data',
+                  type: { type: 'Any' },
+                  description: 'The data you want to log to the console.',
+                  formula: {
+                    type: 'value',
+                    value: '<Data>',
+                  },
+                },
+              ],
+              label: 'Log to console',
+              group: 'debugging',
+              description: 'Log a message to the browser console.',
+            },
+          ],
+        },
+        false: {
+          actions: [
+            {
+              name: '@toddle/logToConsole',
+              arguments: [
+                {
+                  name: 'Label',
+                  description: 'A label for the message.',
+                  formula: { type: 'value', value: '' },
+                },
+                {
+                  name: 'Data',
+                  type: { type: 'Any' },
+                  description: 'The data you want to log to the console.',
+                  formula: {
+                    type: 'value',
+                    value: '<Data>',
+                  },
+                },
+              ],
+              label: 'Log to console',
+              group: 'debugging',
+              description: 'Log a message to the browser console.',
+            },
+          ],
+        },
+      },
+      arguments: [
+        {
+          name: 'Condition',
+          formula: { type: 'value', value: true },
+        },
+      ],
+    }
     const projectFiles: ProjectFiles = {
       formulas: {},
       components: {
@@ -113,75 +176,7 @@ describe('fix legacyActions', () => {
               events: {
                 click: {
                   trigger: 'click',
-                  actions: [
-                    {
-                      name: 'If',
-                      events: {
-                        true: {
-                          actions: [
-                            {
-                              name: '@toddle/logToConsole',
-                              arguments: [
-                                {
-                                  name: 'Label',
-                                  description: 'A label for the message.',
-                                  formula: { type: 'value', value: '' },
-                                },
-                                {
-                                  name: 'Data',
-                                  type: { type: 'Any' },
-                                  description:
-                                    'The data you want to log to the console.',
-                                  formula: {
-                                    type: 'value',
-                                    value: '<Data>',
-                                  },
-                                },
-                              ],
-                              label: 'Log to console',
-                              group: 'debugging',
-                              description:
-                                'Log a message to the browser console.',
-                            },
-                          ],
-                        },
-                        false: {
-                          actions: [
-                            {
-                              name: '@toddle/logToConsole',
-                              arguments: [
-                                {
-                                  name: 'Label',
-                                  description: 'A label for the message.',
-                                  formula: { type: 'value', value: '' },
-                                },
-                                {
-                                  name: 'Data',
-                                  type: { type: 'Any' },
-                                  description:
-                                    'The data you want to log to the console.',
-                                  formula: {
-                                    type: 'value',
-                                    value: '<Data>',
-                                  },
-                                },
-                              ],
-                              label: 'Log to console',
-                              group: 'debugging',
-                              description:
-                                'Log a message to the browser console.',
-                            },
-                          ],
-                        },
-                      },
-                      arguments: [
-                        {
-                          name: 'Condition',
-                          formula: { type: 'value', value: true },
-                        },
-                      ],
-                    },
-                  ],
+                  actions: [legacyIfAction],
                 },
               },
               classes: {},
@@ -203,11 +198,79 @@ describe('fix legacyActions', () => {
     const fixedAction = (
       fixedProject.components['apiComponent']?.nodes['root'] as ElementNodeModel
     ).events['click'].actions[0]
-    expect(fixedAction).toBeDefined()
-    expect((fixedAction as any).type).toBe('Switch')
-    expect((fixedAction as any).cases).toHaveLength(1)
-    expect((fixedAction as any).cases[0].actions).toHaveLength(1)
-    expect((fixedAction as any).default.actions).toHaveLength(1)
+    expect(fixedAction).toMatchInlineSnapshot(`
+      {
+        "cases": [
+          {
+            "actions": [
+              {
+                "arguments": [
+                  {
+                    "description": "A label for the message.",
+                    "formula": {
+                      "type": "value",
+                      "value": "",
+                    },
+                    "name": "Label",
+                  },
+                  {
+                    "description": "The data you want to log to the console.",
+                    "formula": {
+                      "type": "value",
+                      "value": "<Data>",
+                    },
+                    "name": "Data",
+                    "type": {
+                      "type": "Any",
+                    },
+                  },
+                ],
+                "description": "Log a message to the browser console.",
+                "group": "debugging",
+                "label": "Log to console",
+                "name": "@toddle/logToConsole",
+              },
+            ],
+            "condition": {
+              "type": "value",
+              "value": true,
+            },
+          },
+        ],
+        "default": {
+          "actions": [
+            {
+              "arguments": [
+                {
+                  "description": "A label for the message.",
+                  "formula": {
+                    "type": "value",
+                    "value": "",
+                  },
+                  "name": "Label",
+                },
+                {
+                  "description": "The data you want to log to the console.",
+                  "formula": {
+                    "type": "value",
+                    "value": "<Data>",
+                  },
+                  "name": "Data",
+                  "type": {
+                    "type": "Any",
+                  },
+                },
+              ],
+              "description": "Log a message to the browser console.",
+              "group": "debugging",
+              "label": "Log to console",
+              "name": "@toddle/logToConsole",
+            },
+          ],
+        },
+        "type": "Switch",
+      }
+    `)
   })
   test('should replace the TriggerEvent action with the builtin action', () => {
     const legacyAction: ActionModel = {
@@ -259,15 +322,15 @@ describe('fix legacyActions', () => {
     const fixedAction = (
       fixedProject.components['apiComponent']?.nodes['root'] as ElementNodeModel
     ).events['click'].actions[0]
-    expect(fixedAction).toBeDefined()
-    expect((fixedAction as any).type).toBe('TriggerEvent')
-    // the name of the event should be copied over from the arguments
-    expect((fixedAction as any).event).toEqual(
-      (legacyAction.arguments?.[0].formula as any).value,
-    )
-    // the data of the event should be copied over from the arguments
-    expect((fixedAction as any).data).toEqual(
-      legacyAction.arguments?.[1].formula,
-    )
+    expect(fixedAction).toMatchInlineSnapshot(`
+      {
+        "data": {
+          "type": "value",
+          "value": "test",
+        },
+        "event": "sdfsdf",
+        "type": "TriggerEvent",
+      }
+    `)
   })
 })

--- a/packages/search/src/rules/actions/legacyActionRule.ts
+++ b/packages/search/src/rules/actions/legacyActionRule.ts
@@ -1,4 +1,7 @@
-import type { ActionModel } from '@nordcraft/core/dist/component/component.types'
+import type {
+  ActionModel,
+  CustomActionArgument,
+} from '@nordcraft/core/dist/component/component.types'
 import { set } from '@nordcraft/core/dist/utils/collections'
 import type { Rule } from '../../types'
 import { isLegacyAction, renameArguments } from '../../util/helpers'
@@ -48,9 +51,8 @@ export const legacyActionRule: Rule<{
         case 'If': {
           const trueActions = value.events?.['true']?.actions ?? []
           const falseActions = value.events?.['false']?.actions ?? []
-          const trueCondition = (value.arguments ?? []).find(
-            (a) => a.name === 'Condition',
-          )
+          const trueCondition: CustomActionArgument | undefined =
+            (value.arguments ?? [])[0]
           newAction = {
             type: 'Switch',
             cases: [

--- a/packages/search/src/rules/actions/legacyActionRule.ts
+++ b/packages/search/src/rules/actions/legacyActionRule.ts
@@ -1,5 +1,7 @@
+import type { ActionModel } from '@nordcraft/core/dist/component/component.types'
+import { set } from '@nordcraft/core/dist/utils/collections'
 import type { Rule } from '../../types'
-import { isLegacyAction } from '../../util/helpers'
+import { isLegacyAction, renameArguments } from '../../util/helpers'
 
 export const legacyActionRule: Rule<{
   name: string
@@ -11,7 +13,6 @@ export const legacyActionRule: Rule<{
     if (nodeType !== 'action-model') {
       return
     }
-
     if (isLegacyAction(value)) {
       let details: { name: string } | undefined
       if ('name' in value) {
@@ -19,8 +20,167 @@ export const legacyActionRule: Rule<{
           name: value.name,
         }
       }
-
-      report(path, details)
+      report(
+        path,
+        details,
+        unfixableLegacyActions.has(value.name)
+          ? undefined
+          : !formulaNamedActions.includes(value.name) ||
+              // Check if the first argument is a value formula with a string value
+              (value.arguments?.[0].formula.type === 'value' &&
+                typeof value.arguments[0].formula.value === 'string')
+            ? ['replace-legacy-action']
+            : undefined,
+      )
     }
   },
+  fixes: {
+    'replace-legacy-action': ({ path, value, nodeType, files }) => {
+      if (nodeType !== 'action-model') {
+        return
+      }
+      if (!isLegacyAction(value)) {
+        return
+      }
+
+      let newAction: ActionModel | undefined
+      switch (value.name) {
+        case 'If': {
+          const trueActions = value.events?.['true']?.actions ?? []
+          const falseActions = value.events?.['false']?.actions ?? []
+          const trueCondition = (value.arguments ?? []).find(
+            (a) => a.name === 'Condition',
+          )
+          newAction = {
+            type: 'Switch',
+            cases: [
+              {
+                condition: trueCondition?.formula ?? null,
+                actions: trueActions,
+              },
+            ],
+            default: { actions: falseActions },
+          }
+          break
+        }
+        case 'PreventDefault': {
+          newAction = {
+            name: '@toddle/preventDefault',
+            arguments: [],
+            label: 'Prevent default',
+          }
+          break
+        }
+        case 'StopPropagation': {
+          newAction = {
+            name: '@toddle/stopPropagation',
+            arguments: [],
+            label: 'Stop propagation',
+          }
+          break
+        }
+        case 'UpdateVariable': {
+          const variableName =
+            value.arguments?.[0]?.formula.type === 'value'
+              ? value.arguments[0].formula.value
+              : undefined
+          if (typeof variableName !== 'string') {
+            break
+          }
+          const variableValue = value.arguments?.[1]?.formula
+          if (!variableValue) {
+            break
+          }
+          newAction = {
+            type: 'SetVariable',
+            variable: variableName,
+            data: variableValue,
+          }
+          break
+        }
+        case 'SetTimeout': {
+          newAction = {
+            ...value,
+            name: '@toddle/sleep',
+            arguments: renameArguments(
+              { 'Delay in ms': 'Delay in milliseconds' },
+              value.arguments,
+            ),
+            events: value.events?.['timeout']
+              ? { tick: value.events.timeout }
+              : undefined,
+            label: 'Sleep',
+          }
+          break
+        }
+        case 'SetInterval': {
+          newAction = {
+            ...value,
+            name: '@toddle/interval',
+            arguments: renameArguments(
+              { 'Interval in ms': 'Interval in milliseconds' },
+              value.arguments,
+            ),
+            label: 'Interval',
+          }
+          break
+        }
+        case 'Debug': {
+          newAction = {
+            ...value,
+            name: '@toddle/logToConsole',
+            label: 'Log to console',
+          }
+          break
+        }
+        case 'GoToURL': {
+          newAction = {
+            name: '@toddle/gotToURL', // Yes, the typo is in the action name
+            arguments: renameArguments({ url: 'URL' }, value.arguments),
+            label: 'Go to URL',
+          }
+          break
+        }
+        case 'TriggerEvent': {
+          const eventName =
+            value.arguments?.[0]?.formula.type === 'value'
+              ? value.arguments[0].formula.value
+              : undefined
+          if (typeof eventName !== 'string') {
+            break
+          }
+          const eventData = value.arguments?.[1]?.formula
+          if (!eventData) {
+            break
+          }
+          newAction = {
+            type: 'TriggerEvent',
+            event: eventName,
+            data: eventData,
+          }
+          break
+        }
+      }
+      if (newAction) {
+        return set(files, path, newAction)
+      }
+    },
+  },
 }
+
+// These actions take a first argument which is a formula as the name
+// of the thing to update/trigger. We can only safely autofix these if
+// the argument is a value operation and a string
+const formulaNamedActions = ['UpdateVariable', 'TriggerEvent']
+
+const unfixableLegacyActions = new Set([
+  'CopyToClipboard', // Previously, this action would JSON stringify non-string inputs
+  'Update URL parameter', // The user will need to pick a history mode (push/replace)
+  'Fetch', // This was mainly used for APIs v1
+  'FocusElement', // The new 'Focus' action takes an element as input - not a selector
+  'UpdateVariable', // The variable name could be a formula in the legacy version
+  'TriggerEvent', // The name of the event could be a formula in the legacy version
+  '@toddle/setSessionCookies', // The new 'Set cookie' action takes more arguments
+])
+
+export type LegacyActionRuleFix = 'replace-legacy-action'

--- a/packages/search/src/rules/formulas/legacyFormulaRule.ts
+++ b/packages/search/src/rules/formulas/legacyFormulaRule.ts
@@ -1,7 +1,6 @@
 import type {
   AndOperation,
   ArrayOperation,
-  FunctionArgument,
   FunctionOperation,
   OrOperation,
   SwitchOperation,
@@ -11,6 +10,11 @@ import { omitKeys, set } from '@nordcraft/core/dist/utils/collections'
 import { isDefined } from '@nordcraft/core/dist/utils/util'
 import type { ProjectFiles } from '@nordcraft/ssr/dist/ssr.types'
 import type { FormulaNode, NodeType, Rule } from '../../types'
+import {
+  ARRAY_ARGUMENT_MAPPINGS,
+  PREDICATE_ARGUMENT_MAPPINGS,
+  renameArguments,
+} from '../../util/helpers'
 
 export const legacyFormulaRule: Rule<{
   name: string
@@ -839,23 +843,3 @@ const builtInFormulas = new Set([
   'uppercase',
 ])
 // cSpell: enable
-
-const ARRAY_ARGUMENT_MAPPINGS = { List: 'Array' }
-const PREDICATE_ARGUMENT_MAPPINGS = {
-  ...ARRAY_ARGUMENT_MAPPINGS,
-  'Predicate fx': 'Formula',
-}
-
-const renameArguments = (
-  mappings: Record<string, string>,
-  args: FunctionArgument[] | undefined,
-): FunctionArgument[] =>
-  args?.map((arg) => ({
-    ...arg,
-    // Let's adjust the names
-    name:
-      typeof arg.name === 'string'
-        ? // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-          (mappings[arg.name] ?? arg.name)
-        : arg.name,
-  })) ?? []

--- a/packages/search/src/types.d.ts
+++ b/packages/search/src/types.d.ts
@@ -316,7 +316,6 @@ type FixType =
   | LegacyFormulaRuleFix
   | LegacyActionRuleFix
   | NoReferenceComponentRuleFix
-  | NoReferenceProjectFormulaRuleFix
 
 export interface Rule<T = unknown, V = NodeType> {
   category: Category

--- a/packages/search/src/types.d.ts
+++ b/packages/search/src/types.d.ts
@@ -21,6 +21,7 @@ import type {
   Route,
   ToddleProject,
 } from '@nordcraft/ssr/dist/ssr.types'
+import type { LegacyActionRuleFix } from './rules/actions/legacyActionRule'
 import type { NoReferenceComponentRuleFix } from './rules/components/noReferenceComponentRule'
 import type { LegacyFormulaRuleFix } from './rules/formulas/legacyFormulaRule'
 
@@ -311,7 +312,11 @@ export type NodeType =
   | ProjectRoute
   | StyleVariantNode
 
-type FixType = LegacyFormulaRuleFix | NoReferenceComponentRuleFix
+type FixType =
+  | LegacyFormulaRuleFix
+  | LegacyActionRuleFix
+  | NoReferenceComponentRuleFix
+  | NoReferenceProjectFormulaRuleFix
 
 export interface Rule<T = unknown, V = NodeType> {
   category: Category

--- a/packages/search/src/util/helpers.ts
+++ b/packages/search/src/util/helpers.ts
@@ -75,6 +75,7 @@ const LEGACY_CUSTOM_ACTIONS = new Set([
   'Debug',
   'GoToURL',
   'TriggerEvent',
+  'Set session cookies',
   '@toddle/setSessionCookies',
 ])
 

--- a/packages/search/src/util/helpers.ts
+++ b/packages/search/src/util/helpers.ts
@@ -1,7 +1,10 @@
 import type {
   ActionModel,
+  CustomActionArgument,
+  CustomActionModel,
   ElementNodeModel,
 } from '@nordcraft/core/dist/component/component.types'
+import type { FunctionArgument } from '@nordcraft/core/dist/formula/formula'
 import { isDefined } from '@nordcraft/core/dist/utils/util'
 
 /**
@@ -44,7 +47,9 @@ export function shouldSearchExactPath({
   )
 }
 
-export const isLegacyAction = (model: ActionModel) => {
+export const isLegacyAction = (
+  model: ActionModel,
+): model is CustomActionModel => {
   switch (model.type) {
     case 'Custom':
     case undefined:
@@ -58,14 +63,11 @@ const LEGACY_CUSTOM_ACTIONS = new Set([
   'If',
   'PreventDefault',
   'StopPropagation',
-  'Copy To Clipboard',
   'CopyToClipboard',
   'UpdateVariable',
-  'Update Variable',
   'Update URL parameter',
   'updateUrlParameters',
   'UpdateQueryParam',
-  'Update Query',
   'Fetch',
   'SetTimeout',
   'SetInterval',
@@ -73,7 +75,7 @@ const LEGACY_CUSTOM_ACTIONS = new Set([
   'Debug',
   'GoToURL',
   'TriggerEvent',
-  'Set session cookies',
+  '@toddle/setSessionCookies',
 ])
 
 interface BaseInteractiveContent {
@@ -130,3 +132,24 @@ export const interactiveContentElementDefinition = (
     }
     return true
   })
+
+export const ARRAY_ARGUMENT_MAPPINGS = { List: 'Array' }
+export const PREDICATE_ARGUMENT_MAPPINGS = {
+  ...ARRAY_ARGUMENT_MAPPINGS,
+  'Predicate fx': 'Formula',
+}
+
+export const renameArguments = <
+  T extends FunctionArgument | CustomActionArgument,
+>(
+  mappings: Record<string, string>,
+  args: T[] | undefined,
+): T[] =>
+  args?.map((arg) => ({
+    ...arg,
+    // Let's adjust the names
+    name:
+      typeof arg.name === 'string'
+        ? (mappings[arg.name] ?? arg.name)
+        : arg.name,
+  })) ?? []


### PR DESCRIPTION
Add support for autofixing uses of these legacy actions:

- If
- PreventDefault
- StopPropagation
- UpdateVariable
- SetTimeout
- SetInterval
- Debug
- GoToURL
- TriggerEvent

I did not add support for fixing these legacy actions as they require manual intervention by the user:

- CopyToClipboard
- Update URL parameter
- Fetch
- FocusElement
- UpdateVariable
- TriggerEvent
- @toddle/setSessionCookies

I also updated our types to better reflect the data we see in actual projects.