### PR TITLE
Add missing display_name when fixing focus action

### DIFF
--- a/packages/search/src/rules/actions/legacyActionRule.test.ts
+++ b/packages/search/src/rules/actions/legacyActionRule.test.ts
@@ -393,6 +393,7 @@ describe('fix legacyActions', () => {
                   "name": "Id",
                 },
               ],
+              "display_name": "Get element by id",
               "name": "@toddle/getElementById",
               "type": "function",
             },

--- a/packages/search/src/rules/actions/legacyActionRule.ts
+++ b/packages/search/src/rules/actions/legacyActionRule.ts
@@ -173,6 +173,7 @@ export const legacyActionRule: Rule<{
                 formula: {
                   type: 'function',
                   name: '@toddle/getElementById',
+                  display_name: 'Get element by id',
                   arguments: [
                     {
                       name: 'Id',


### PR DESCRIPTION
I forgot to add a display_name which meant the formula would look strange in the editor