### PR TITLE
Improve test data removal from actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nordcraft",
   "type": "module",
   "license": "Apache-2.0",
-  "version": "1.0.43",
+  "version": "1.0.44",
   "homepage": "https://github.com/nordcraftengine/nordcraft",
   "private": "false",
   "workspaces": [

--- a/packages/backend/src/routes/apiProxy.ts
+++ b/packages/backend/src/routes/apiProxy.ts
@@ -73,10 +73,12 @@ export const proxyRequestHandler = async (
           // Parse form data, apply templates to values, then re-encode
           templateBody = new URLSearchParams(
             Object.fromEntries(
-              new URLSearchParams(bodyText).entries().map(([key, value]) => [
-                key,
-                applyTemplateValues(value, requestCookies),
-              ]),
+              new URLSearchParams(bodyText)
+                .entries()
+                .map(([key, value]) => [
+                  key,
+                  applyTemplateValues(value, requestCookies),
+                ]),
             ),
           ).toString()
         } else {

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "build": "tsc",
     "npm-publish": "bun run build && bun publish --access public",
+    "test:watch": "bun test --watch",
+    "test:watch:only": "bun test --watch --only",
     "typecheck": "tsc --noEmit",
     "watch": "tsc -w"
   },

--- a/packages/ssr/src/rendering/testData.test.ts
+++ b/packages/ssr/src/rendering/testData.test.ts
@@ -1,4 +1,5 @@
 import { valueFormula } from '@nordcraft/core/dist/formula/formulaUtils'
+import { describe, expect, test } from 'bun:test'
 import { removeTestData } from './testData'
 
 describe('removeTestData', () => {
@@ -20,7 +21,7 @@ describe('removeTestData', () => {
       '1': {
         name: 'foo',
       },
-    })
+    } as any)
   })
   test('it removes testValue from route parameters', () => {
     expect(
@@ -66,7 +67,7 @@ describe('removeTestData', () => {
           name: 'q',
         },
       },
-    })
+    } as any)
   })
   test('it removes testValue from formula arguments', () => {
     expect(
@@ -93,7 +94,7 @@ describe('removeTestData', () => {
       {
         name: 'bar',
       },
-    ])
+    ] as any)
   })
   test('it removes testValue from workflow parameters', () => {
     expect(
@@ -120,7 +121,7 @@ describe('removeTestData', () => {
       {
         name: 'bar',
       },
-    ])
+    ] as any)
   })
   test('it removes description from workflow actions', () => {
     expect(
@@ -182,5 +183,159 @@ describe('removeTestData', () => {
       type: 'http',
       inputs: {},
     })
+  })
+  test('it removes test data from actions', () => {
+    const updatedData = removeTestData({
+      name: 'test',
+      variables: {},
+      nodes: {
+        root: {
+          tag: 'div',
+          type: 'element',
+          attrs: {},
+          style: {},
+          events: {
+            onClick: {
+              trigger: 'click',
+              actions: [
+                {
+                  type: 'Custom',
+                  name: 'My Action',
+                  description: 'A long description',
+                  group: 'Group 1',
+                  label: 'Label 1',
+                  arguments: [
+                    {
+                      name: 'arg1',
+                      formula: valueFormula('value1'),
+                      type: 'Array',
+                      description: 'Argument 1',
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+          classes: {},
+          children: [],
+        },
+      },
+      attributes: {},
+      apis: {},
+      onLoad: {
+        trigger: 'onLoad',
+        actions: [
+          {
+            type: 'Custom',
+            name: 'My Action',
+            description: 'A long description',
+            group: 'Group 1',
+            label: 'Label 1',
+            arguments: [
+              {
+                name: 'arg1',
+                formula: valueFormula('value1'),
+                type: 'Array',
+                description: 'Argument 1',
+              },
+            ],
+          },
+        ],
+      },
+      onAttributeChange: {
+        trigger: 'onAttributeChange',
+        actions: [
+          {
+            type: 'Custom',
+            name: 'My Action',
+            description: 'A long description',
+            group: 'Group 1',
+            label: 'Label 1',
+            arguments: [
+              {
+                name: 'arg1',
+                formula: valueFormula('value1'),
+                type: 'Array',
+                description: 'Argument 1',
+              },
+            ],
+          },
+        ],
+      },
+    })
+    expect(updatedData).toMatchInlineSnapshot(`
+      {
+        "apis": {},
+        "attributes": {},
+        "name": "test",
+        "nodes": {
+          "root": {
+            "attrs": {},
+            "children": [],
+            "classes": {},
+            "events": {
+              "onClick": {
+                "actions": [
+                  {
+                    "arguments": [
+                      {
+                        "formula": {
+                          "type": "value",
+                          "value": "value1",
+                        },
+                        "name": "arg1",
+                      },
+                    ],
+                    "name": "My Action",
+                    "type": "Custom",
+                  },
+                ],
+                "trigger": "click",
+              },
+            },
+            "style": {},
+            "tag": "div",
+            "type": "element",
+          },
+        },
+        "onAttributeChange": {
+          "actions": [
+            {
+              "arguments": [
+                {
+                  "formula": {
+                    "type": "value",
+                    "value": "value1",
+                  },
+                  "name": "arg1",
+                },
+              ],
+              "name": "My Action",
+              "type": "Custom",
+            },
+          ],
+          "trigger": "onAttributeChange",
+        },
+        "onLoad": {
+          "actions": [
+            {
+              "arguments": [
+                {
+                  "formula": {
+                    "type": "value",
+                    "value": "value1",
+                  },
+                  "name": "arg1",
+                },
+              ],
+              "name": "My Action",
+              "type": "Custom",
+            },
+          ],
+          "trigger": "onLoad",
+        },
+        "variables": {},
+      }
+    `)
   })
 })

--- a/packages/ssr/src/rendering/testData.ts
+++ b/packages/ssr/src/rendering/testData.ts
@@ -4,18 +4,14 @@ import type {
   Component,
   CustomActionArgument,
 } from '@nordcraft/core/dist/component/component.types'
-import {
-  mapObject,
-  omit,
-  omitKeys,
-} from '@nordcraft/core/dist/utils/collections'
+import { mapObject, omitKeys } from '@nordcraft/core/dist/utils/collections'
 
 export function removeTestData(component: Component): Component {
   return {
     ...component,
     attributes: mapObject(component.attributes, ([key, value]) => [
       key,
-      omit(value, ['testValue']),
+      omitKeys(value, ['testValue']),
     ]),
     nodes: mapObject(component.nodes, ([key, value]) => {
       let events = {}
@@ -34,10 +30,10 @@ export function removeTestData(component: Component): Component {
       ? {
           route: {
             ...component.route,
-            path: component.route.path.map((p) => omit(p, ['testValue'])),
+            path: component.route.path.map((p) => omitKeys(p, ['testValue'])),
             query: mapObject(component.route.query, ([key, value]) => [
               key,
-              omit(value, ['testValue']),
+              omitKeys(value, ['testValue']),
             ]),
           },
         }
@@ -48,9 +44,8 @@ export function removeTestData(component: Component): Component {
             key,
             {
               ...value,
-              // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
               arguments: (value.arguments ?? []).map((a) =>
-                omit(a, ['testValue']),
+                omitKeys(a, ['testValue']),
               ),
             },
           ]),
@@ -67,7 +62,7 @@ export function removeTestData(component: Component): Component {
               actions: value.actions.map(removeActionTestData),
               // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
               parameters: (value.parameters || []).map((p) =>
-                omit(p, ['testValue']),
+                omitKeys(p, ['testValue']),
               ),
             },
           ]),

--- a/packages/ssr/src/rendering/testData.ts
+++ b/packages/ssr/src/rendering/testData.ts
@@ -1,5 +1,9 @@
 import { isLegacyApi } from '@nordcraft/core/dist/api/api'
-import type { Component } from '@nordcraft/core/dist/component/component.types'
+import type {
+  ActionModel,
+  Component,
+  CustomActionArgument,
+} from '@nordcraft/core/dist/component/component.types'
 import {
   mapObject,
   omit,
@@ -13,6 +17,19 @@ export function removeTestData(component: Component): Component {
       key,
       omit(value, ['testValue']),
     ]),
+    nodes: mapObject(component.nodes, ([key, value]) => {
+      let events = {}
+      if (value.type === 'element') {
+        events = mapObject(value.events, ([eventKey, eventValue]) => [
+          eventKey,
+          {
+            ...eventValue,
+            actions: eventValue.actions.map(removeActionTestData),
+          },
+        ])
+      }
+      return [key, { ...value, events }]
+    }),
     ...(component.route
       ? {
           route: {
@@ -47,9 +64,7 @@ export function removeTestData(component: Component): Component {
               ...value,
               // We should find all actions (also nested actions and non-workflow actions) and remove
               // the description from them. This is a start though
-              actions: value.actions.map((a) =>
-                a.type === 'Custom' ? omitKeys(a, ['description']) : a,
-              ),
+              actions: value.actions.map(removeActionTestData),
               // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
               parameters: (value.parameters || []).map((p) =>
                 omit(p, ['testValue']),
@@ -65,5 +80,31 @@ export function removeTestData(component: Component): Component {
       // request is available on the api object itself
       isLegacyApi(api) ? api : omitKeys(api, ['service', 'servicePath']),
     ]),
+    onLoad: component.onLoad
+      ? {
+          ...component.onLoad,
+          actions: component.onLoad.actions.map(removeActionTestData),
+        }
+      : undefined,
+    onAttributeChange: component.onAttributeChange
+      ? {
+          ...component.onAttributeChange,
+          actions:
+            component.onAttributeChange.actions.map(removeActionTestData),
+        }
+      : undefined,
   }
 }
+
+const removeActionTestData = (action: ActionModel) => {
+  if (action.type === 'Custom') {
+    return {
+      ...omitKeys(action, ['description', 'group', 'label']),
+      arguments: action.arguments?.map(removeActionArgumentTestData),
+    }
+  }
+  return action
+}
+
+const removeActionArgumentTestData = (action: CustomActionArgument) =>
+  omitKeys(action, ['description', 'type'])

--- a/packages/ssr/src/rendering/testData.ts
+++ b/packages/ssr/src/rendering/testData.ts
@@ -3,97 +3,102 @@ import type {
   ActionModel,
   Component,
   CustomActionArgument,
+  NodeModel,
 } from '@nordcraft/core/dist/component/component.types'
 import { mapObject, omitKeys } from '@nordcraft/core/dist/utils/collections'
+import { isDefined } from '@nordcraft/core/dist/utils/util'
 
-export function removeTestData(component: Component): Component {
-  return {
-    ...component,
-    attributes: mapObject(component.attributes, ([key, value]) => [
-      key,
-      omitKeys(value, ['testValue']),
-    ]),
-    nodes: mapObject(component.nodes, ([key, value]) => {
-      let events = {}
-      if (value.type === 'element') {
-        events = mapObject(value.events, ([eventKey, eventValue]) => [
+export const removeTestData = (component: Component): Component => ({
+  ...component,
+  attributes: mapObject(component.attributes, ([key, value]) => [
+    key,
+    omitKeys(value, ['testValue']),
+  ]),
+  nodes: mapObject(component.nodes, ([key, value]) => {
+    if ('events' in value && isDefined(value.events)) {
+      const updatedNode: NodeModel = {
+        ...value,
+        events: mapObject(value.events, ([eventKey, eventValue]) => [
           eventKey,
           {
             ...eventValue,
             actions: eventValue.actions.map(removeActionTestData),
           },
-        ])
+        ]),
       }
-      return [key, { ...value, events }]
-    }),
-    ...(component.route
-      ? {
-          route: {
-            ...component.route,
-            path: component.route.path.map((p) => omitKeys(p, ['testValue'])),
-            query: mapObject(component.route.query, ([key, value]) => [
-              key,
-              omitKeys(value, ['testValue']),
-            ]),
+      return [key, updatedNode as NodeModel]
+    }
+    return [key, value]
+  }),
+  ...(component.route
+    ? {
+        route: {
+          ...component.route,
+          path: component.route.path.map((p) => omitKeys(p, ['testValue'])),
+          query: mapObject(component.route.query, ([key, value]) => [
+            key,
+            omitKeys(value, ['testValue']),
+          ]),
+        },
+      }
+    : {}),
+  ...(component.formulas
+    ? {
+        formulas: mapObject(component.formulas, ([key, value]) => [
+          key,
+          {
+            ...value,
+            arguments: (value.arguments ?? []).map((a) =>
+              omitKeys(a, ['testValue']),
+            ),
           },
-        }
-      : {}),
-    ...(component.formulas
-      ? {
-          formulas: mapObject(component.formulas, ([key, value]) => [
-            key,
-            {
-              ...value,
-              arguments: (value.arguments ?? []).map((a) =>
-                omitKeys(a, ['testValue']),
-              ),
-            },
-          ]),
-        }
-      : {}),
-    ...(component.workflows
-      ? {
-          workflows: mapObject(component.workflows, ([key, value]) => [
-            key,
-            {
-              ...value,
-              // We should find all actions (also nested actions and non-workflow actions) and remove
-              // the description from them. This is a start though
-              actions: value.actions.map(removeActionTestData),
-              // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-              parameters: (value.parameters || []).map((p) =>
-                omitKeys(p, ['testValue']),
-              ),
-            },
-          ]),
-        }
-      : {}),
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    apis: mapObject(component.apis ?? {}, ([key, api]) => [
-      key,
-      // service and servicePath are only necessary in the editor. All information about an API
-      // request is available on the api object itself
-      isLegacyApi(api) ? api : omitKeys(api, ['service', 'servicePath']),
-    ]),
-    onLoad: component.onLoad
-      ? {
-          ...component.onLoad,
-          actions: component.onLoad.actions.map(removeActionTestData),
-        }
-      : undefined,
-    onAttributeChange: component.onAttributeChange
-      ? {
-          ...component.onAttributeChange,
-          actions:
-            component.onAttributeChange.actions.map(removeActionTestData),
-        }
-      : undefined,
-  }
-}
+        ]),
+      }
+    : {}),
+  ...(component.workflows
+    ? {
+        workflows: mapObject(component.workflows, ([key, value]) => [
+          key,
+          {
+            ...value,
+            // We should find all actions (also nested actions and non-workflow actions) and remove
+            // the description from them. This is a start though
+            actions: value.actions.map(removeActionTestData),
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+            parameters: (value.parameters || []).map((p) =>
+              omitKeys(p, ['testValue']),
+            ),
+          },
+        ]),
+      }
+    : {}),
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  apis: mapObject(component.apis ?? {}, ([key, api]) => [
+    key,
+    // service and servicePath are only necessary in the editor. All information about an API
+    // request is available on the api object itself
+    isLegacyApi(api) ? api : omitKeys(api, ['service', 'servicePath']),
+  ]),
+  onLoad: component.onLoad
+    ? {
+        ...component.onLoad,
+        actions: component.onLoad.actions.map(removeActionTestData),
+      }
+    : undefined,
+  onAttributeChange: component.onAttributeChange
+    ? {
+        ...component.onAttributeChange,
+        actions: component.onAttributeChange.actions.map(removeActionTestData),
+      }
+    : undefined,
+})
 
 const removeActionTestData = (action: ActionModel) => {
   if (action.type === 'Custom') {
     return {
+      // The 'group' property was used for categorizing actions and should
+      // not have been persisted in projects. But since it's there (for some actions)
+      // we should remove it
       ...omitKeys(action, ['description', 'group', 'label']),
       arguments: action.arguments?.map(removeActionArgumentTestData),
     }


### PR DESCRIPTION
We were not removing description, group and label from custom actions during test data removal.

I have been testing this change on a few projects, including the editor project 👍 