### PR TITLE
Visit nodes in "no-reference node" rule

### DIFF
--- a/packages/search/src/rules/noReferenceNodeRule.test.ts
+++ b/packages/search/src/rules/noReferenceNodeRule.test.ts
@@ -130,7 +130,7 @@ describe('fix noReferenceNodeRule', () => {
     const fixedFiles = fixProject({
       files,
       rule: noReferenceNodeRule,
-      fixType: 'delete orphan node',
+      fixType: 'delete-orphan-node',
     })
     expect(Object.keys(fixedFiles.components.test!.nodes)).toEqual([
       'root',

--- a/packages/search/src/rules/style/invalidStyleSyntaxRule.test.ts
+++ b/packages/search/src/rules/style/invalidStyleSyntaxRule.test.ts
@@ -92,7 +92,7 @@ describe('fix invalidStyleSyntaxRule', () => {
     const fixedFiles = fixProject({
       files,
       rule: invalidStyleSyntaxRule,
-      fixType: 'delete style property',
+      fixType: 'delete-style-property',
     })
     expect((fixedFiles.components.test!.nodes.root as ElementNodeModel).style)
       .toMatchInlineSnapshot(`

--- a/packages/search/src/rules/style/invalidStyleSyntaxRule.ts
+++ b/packages/search/src/rules/style/invalidStyleSyntaxRule.ts
@@ -24,12 +24,12 @@ export const invalidStyleSyntaxRule: Rule<{
       },
     )
     if (!valid) {
-      report(path, { property: value.styleProperty }, ['delete style property'])
+      report(path, { property: value.styleProperty }, ['delete-style-property'])
     }
   },
   fixes: {
-    'delete style property': removeFromPathFix,
+    'delete-style-property': removeFromPathFix,
   },
 }
 
-export type InvalidStyleSyntaxRuleFix = 'delete style property'
+export type InvalidStyleSyntaxRuleFix = 'delete-style-property'


### PR DESCRIPTION
Instead of visiting all nodes in a component, we should let the "no-reference node" rule visit individual nodes. That makes it easier to apply the fix of a reported issue since the path will match 1:1 with the node to be fixed.

I also adjusted a few fix types to be more consistent. I will need to adjust those in the editor as well when this is going live.