### PR TITLE
Issue rule to reduce static formulas

### DIFF
--- a/packages/search/src/problems.worker.ts
+++ b/packages/search/src/problems.worker.ts
@@ -37,6 +37,7 @@ import { unknownFormulaRule } from './rules/formulas/unknownFormulaRule'
 import { unknownProjectFormulaRule } from './rules/formulas/unknownProjectFormulaRule'
 import { unknownRepeatIndexFormulaRule } from './rules/formulas/unknownRepeatIndexFormulaRule'
 import { unknownRepeatItemFormulaRule } from './rules/formulas/unknownRepeatItemFormulaRule'
+import { noStaticNodeCondition } from './rules/logic/noStaticNodeCondition'
 import { noUnnecessaryConditionFalsy } from './rules/logic/noUnnecessaryConditionFalsy'
 import { noUnnecessaryConditionTruthy } from './rules/logic/noUnnecessaryConditionTruthy'
 import { noReferenceNodeRule } from './rules/noReferenceNodeRule'
@@ -162,6 +163,7 @@ const RULES = [
   noReferenceProjectActionRule,
   noReferenceProjectFormulaRule,
   noReferenceVariableRule,
+  noStaticNodeCondition,
   noUnnecessaryConditionFalsy,
   noUnnecessaryConditionTruthy,
   requireExtensionRule,

--- a/packages/search/src/rules/logic/noStaticNodeCondition.test.ts
+++ b/packages/search/src/rules/logic/noStaticNodeCondition.test.ts
@@ -1,0 +1,290 @@
+import type { ProjectFiles } from '@nordcraft/ssr/dist/ssr.types'
+import { describe, expect, test } from 'bun:test'
+import { fixProject } from '../../fixProject'
+import { searchProject } from '../../searchProject'
+import { noStaticNodeCondition } from './noStaticNodeCondition'
+
+describe('noStaticNodeCondition', () => {
+  test('should report node condition that is always truthy', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          components: {
+            test: {
+              name: 'test',
+              nodes: {
+                root: {
+                  type: 'element',
+                  attrs: {},
+                  classes: {},
+                  events: {},
+                  tag: 'div',
+                  children: [],
+                  style: {},
+                  condition: {
+                    type: 'value',
+                    value: true,
+                  },
+                },
+              },
+              formulas: {},
+              apis: {},
+              attributes: {},
+              variables: {},
+            },
+          },
+        },
+        rules: [noStaticNodeCondition],
+      }),
+    )
+
+    expect(problems).toHaveLength(1)
+    expect(problems[0].code).toBe('no-static-node-condition')
+    expect(problems[0].details).toEqual({
+      result: true,
+    })
+    expect(problems[0].fixes).toEqual(['remove-condition'])
+    expect(problems[0].path).toEqual([
+      'components',
+      'test',
+      'nodes',
+      'root',
+      'condition',
+    ])
+  })
+
+  test('should report node condition that is always falsy', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          components: {
+            test: {
+              name: 'test',
+              nodes: {
+                root: {
+                  type: 'element',
+                  attrs: {},
+                  classes: {},
+                  events: {},
+                  tag: 'div',
+                  children: [],
+                  style: {},
+                  condition: {
+                    type: 'value',
+                    value: false,
+                  },
+                },
+              },
+              formulas: {},
+              apis: {},
+              attributes: {},
+              variables: {},
+            },
+          },
+        },
+        rules: [noStaticNodeCondition],
+      }),
+    )
+
+    expect(problems).toHaveLength(1)
+    expect(problems[0].code).toBe('no-static-node-condition')
+    expect(problems[0].details).toEqual({
+      result: false,
+    })
+  })
+
+  test('should not report node condition that is dynamic', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          components: {
+            test: {
+              name: 'test',
+              nodes: {
+                root: {
+                  type: 'element',
+                  attrs: {},
+                  classes: {},
+                  events: {},
+                  tag: 'div',
+                  children: [],
+                  style: {},
+                  condition: {
+                    type: 'apply',
+                    name: 'randomNumber',
+                    arguments: [],
+                  },
+                },
+              },
+              formulas: {},
+              apis: {},
+              attributes: {},
+              variables: {},
+            },
+          },
+        },
+        rules: [noStaticNodeCondition],
+      }),
+    )
+
+    expect(problems).toHaveLength(0)
+  })
+
+  test('should fix static truthy condition by removing the condition', () => {
+    const files: ProjectFiles = {
+      components: {
+        test: {
+          name: 'test',
+          nodes: {
+            root: {
+              type: 'element',
+              attrs: {},
+              classes: {},
+              events: {},
+              tag: 'div',
+              children: [],
+              style: {},
+              condition: {
+                type: 'value',
+                value: true,
+              },
+            },
+          },
+          formulas: {},
+          apis: {},
+          attributes: {},
+          variables: {},
+        },
+      },
+    }
+    const fixedFiles = fixProject({
+      files,
+      rule: noStaticNodeCondition,
+      fixType: 'remove-condition',
+    })
+    expect(fixedFiles).toMatchInlineSnapshot(`
+      {
+        "components": {
+          "test": {
+            "apis": {},
+            "attributes": {},
+            "formulas": {},
+            "name": "test",
+            "nodes": {
+              "root": {
+                "attrs": {},
+                "children": [],
+                "classes": {},
+                "events": {},
+                "style": {},
+                "tag": "div",
+                "type": "element",
+              },
+            },
+            "variables": {},
+          },
+        },
+      }
+    `)
+  })
+
+  test("should fix static falsy condition by removing the node and any parents' references to it", () => {
+    const files: ProjectFiles = {
+      components: {
+        test: {
+          name: 'test',
+          nodes: {
+            root: {
+              type: 'element',
+              attrs: {},
+              classes: {},
+              events: {},
+              tag: 'div',
+              children: ['alwaysHiddenElement', 'sometimesVisibleElement'],
+              style: {},
+            },
+            alwaysHiddenElement: {
+              type: 'element',
+              attrs: {},
+              classes: {},
+              events: {},
+              tag: 'div',
+              children: [],
+              style: {},
+              condition: {
+                type: 'value',
+                value: false,
+              },
+            },
+            sometimesVisibleElement: {
+              type: 'element',
+              attrs: {},
+              classes: {},
+              events: {},
+              tag: 'div',
+              children: [],
+              style: {},
+              condition: {
+                type: 'path',
+                path: ['Variables', 'maybe'],
+              },
+            },
+          },
+          formulas: {},
+          apis: {},
+          attributes: {},
+          variables: {},
+        },
+      },
+    }
+
+    const fixedFiles = fixProject({
+      files,
+      rule: noStaticNodeCondition,
+      fixType: 'remove-node',
+    })
+
+    expect(fixedFiles).toMatchInlineSnapshot(`
+      {
+        "components": {
+          "test": {
+            "apis": {},
+            "attributes": {},
+            "formulas": {},
+            "name": "test",
+            "nodes": {
+              "root": {
+                "attrs": {},
+                "children": [
+                  "sometimesVisibleElement",
+                ],
+                "classes": {},
+                "events": {},
+                "style": {},
+                "tag": "div",
+                "type": "element",
+              },
+              "sometimesVisibleElement": {
+                "attrs": {},
+                "children": [],
+                "classes": {},
+                "condition": {
+                  "path": [
+                    "Variables",
+                    "maybe",
+                  ],
+                  "type": "path",
+                },
+                "events": {},
+                "style": {},
+                "tag": "div",
+                "type": "element",
+              },
+            },
+            "variables": {},
+          },
+        },
+      }
+    `)
+  })
+})

--- a/packages/search/src/rules/logic/noStaticNodeCondition.ts
+++ b/packages/search/src/rules/logic/noStaticNodeCondition.ts
@@ -1,0 +1,43 @@
+import type { FixFunction, NodeType, Rule } from '../../types'
+import { contextlessEvaluateFormula } from '../../util/contextlessEvaluateFormula'
+import {
+  removeFromPathFix,
+  removeNodeFromPathFix,
+} from '../../util/removeUnused.fix'
+
+export const noStaticNodeCondition: Rule<{
+  result: ReturnType<typeof contextlessEvaluateFormula>['result']
+}> = {
+  code: 'no-static-node-condition',
+  level: 'info',
+  category: 'Quality',
+  visit: (report, { path: nodePath, value, nodeType }) => {
+    if (nodeType !== 'component-node' || !value.condition) {
+      return
+    }
+
+    const { isStatic, result } = contextlessEvaluateFormula(value.condition)
+    if (isStatic) {
+      const conditionPath = [...nodePath, 'condition']
+      // - if truthy: "Condition is always true, you can safely remove the condition as it will always be rendered."
+      // - if falsy: "Condition is always false, you can safely remove the entire node as it will never be rendered."
+      report(
+        conditionPath,
+        {
+          result,
+        },
+        Boolean(result) === true ? ['remove-condition'] : ['remove-node'],
+      )
+    }
+  },
+  fixes: {
+    'remove-condition': removeFromPathFix,
+    'remove-node': (({ path, ...data }) =>
+      removeNodeFromPathFix({
+        path: path.slice(0, -1),
+        ...data,
+      })) as FixFunction<NodeType>,
+  },
+}
+
+export type NoStaticNodeConditionRuleFix = 'remove-condition' | 'remove-node'

--- a/packages/search/src/rules/logic/noStaticNodeCondition.ts
+++ b/packages/search/src/rules/logic/noStaticNodeCondition.ts
@@ -9,7 +9,7 @@ export const noStaticNodeCondition: Rule<{
   result: ReturnType<typeof contextlessEvaluateFormula>['result']
 }> = {
   code: 'no-static-node-condition',
-  level: 'info',
+  level: 'warning',
   category: 'Quality',
   visit: (report, { path: nodePath, value, nodeType }) => {
     if (nodeType !== 'component-node' || !value.condition) {

--- a/packages/search/src/rules/logic/noUnnecessaryConditionFalsy.ts
+++ b/packages/search/src/rules/logic/noUnnecessaryConditionFalsy.ts
@@ -1,4 +1,5 @@
 import type { Rule } from '../../types'
+import { contextlessEvaluateFormula } from '../../util/contextlessEvaluateFormula'
 
 export const noUnnecessaryConditionFalsy: Rule = {
   code: 'no-unnecessary-condition-falsy',
@@ -10,10 +11,10 @@ export const noUnnecessaryConditionFalsy: Rule = {
     }
 
     if (
-      value.arguments.some(
-        (arg) =>
-          arg.formula.type === 'value' && Boolean(arg.formula.value) === false,
-      )
+      value.arguments.some((arg) => {
+        const { result, isStatic } = contextlessEvaluateFormula(arg.formula)
+        return isStatic && Boolean(result) === false
+      })
     ) {
       report(path)
     }

--- a/packages/search/src/rules/logic/noUnnecessaryConditionTruthy.test.ts
+++ b/packages/search/src/rules/logic/noUnnecessaryConditionTruthy.test.ts
@@ -32,7 +32,41 @@ describe('noUnnecessaryConditionTruthy', () => {
                         },
                       ],
                     },
-                    test2: {
+                  },
+                  classes: {},
+                  events: {},
+                  tag: 'div',
+                  children: [],
+                  style: {},
+                },
+              },
+              formulas: {},
+              apis: {},
+              attributes: {},
+              variables: {},
+            },
+          },
+        },
+        rules: [noUnnecessaryConditionTruthy],
+      }),
+    )
+
+    expect(problems).toHaveLength(1)
+    expect(problems[0].code).toBe('no-unnecessary-condition-truthy')
+  })
+
+  test('should report unnecessary truthy conditions when a value is of type object or array as they are always consider truthy', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          components: {
+            test: {
+              name: 'test',
+              nodes: {
+                root: {
+                  type: 'element',
+                  attrs: {
+                    test1: {
                       type: 'or',
                       arguments: [
                         {
@@ -43,7 +77,7 @@ describe('noUnnecessaryConditionTruthy', () => {
                         },
                       ],
                     },
-                    test3: {
+                    test2: {
                       type: 'or',
                       arguments: [
                         {
@@ -73,10 +107,9 @@ describe('noUnnecessaryConditionTruthy', () => {
       }),
     )
 
-    expect(problems).toHaveLength(3)
+    expect(problems).toHaveLength(2)
     expect(problems[0].code).toBe('no-unnecessary-condition-truthy')
     expect(problems[1].code).toBe('no-unnecessary-condition-truthy')
-    expect(problems[2].code).toBe('no-unnecessary-condition-truthy')
   })
 
   test('should not report necessary truthy conditions', () => {

--- a/packages/search/src/rules/logic/noUnnecessaryConditionTruthy.ts
+++ b/packages/search/src/rules/logic/noUnnecessaryConditionTruthy.ts
@@ -1,4 +1,5 @@
 import type { Rule } from '../../types'
+import { contextlessEvaluateFormula } from '../../util/contextlessEvaluateFormula'
 
 export const noUnnecessaryConditionTruthy: Rule = {
   code: 'no-unnecessary-condition-truthy',
@@ -10,14 +11,15 @@ export const noUnnecessaryConditionTruthy: Rule = {
     }
 
     if (
-      value.arguments.some(
-        (arg) =>
-          (arg.formula.type === 'value' &&
-            Boolean(arg.formula.value) === true) ||
-          // Objects and arrays, even empty ones, are always truthy
-          arg.formula.type === 'object' ||
-          arg.formula.type === 'array',
-      )
+      value.arguments.some((arg) => {
+        // Objects and arrays, even empty ones, are always truthy
+        if (arg.formula.type === 'object' || arg.formula.type === 'array') {
+          return true
+        }
+
+        const { result, isStatic } = contextlessEvaluateFormula(arg.formula)
+        return isStatic && Boolean(result) === true
+      })
     ) {
       report(path)
     }

--- a/packages/search/src/types.d.ts
+++ b/packages/search/src/types.d.ts
@@ -30,6 +30,7 @@ import type { NoReferenceEventRuleFix } from './rules/events/noReferenceEventRul
 import type { LegacyFormulaRuleFix } from './rules/formulas/legacyFormulaRule'
 import type { NoReferenceComponentFormulaRuleFix } from './rules/formulas/noReferenceComponentFormulaRule'
 import type { NoReferenceProjectFormulaRuleFix } from './rules/formulas/noReferenceProjectFormulaRule'
+import type { NoStaticNodeConditionRuleFix } from './rules/logic/noStaticNodeConditionRule'
 import type { NoReferenceNodeRuleFix } from './rules/noReferenceNodeRule'
 import type { InvalidStyleSyntaxRuleFix } from './rules/style/invalidStyleSyntaxRule'
 
@@ -59,6 +60,7 @@ type Code =
   | 'no-reference project action'
   | 'no-reference project formula'
   | 'no-reference variable'
+  | 'no-static-node-condition'
   | 'no-unnecessary-condition-falsy'
   | 'no-unnecessary-condition-truthy'
   | 'non-empty void element'
@@ -343,6 +345,7 @@ type FixType =
   | NoReferenceComponentFormulaRuleFix
   | NoReferenceNodeRuleFix
   | InvalidStyleSyntaxRuleFix
+  | NoStaticNodeConditionRuleFix
 
 export interface Rule<T = unknown, V = NodeType> {
   category: Category

--- a/packages/search/src/util/contextlessEvaluateFormula.test.ts
+++ b/packages/search/src/util/contextlessEvaluateFormula.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, test } from 'bun:test'
+import { contextlessEvaluateFormula } from './contextlessEvaluateFormula'
+
+describe('contextlessEvaluateFormula', () => {
+  test('should return `true` when the formula is a simple value formula', () => {
+    expect(
+      contextlessEvaluateFormula({
+        type: 'value',
+        value: true,
+      }),
+    ).toEqual({
+      isStatic: true,
+      result: true,
+    })
+  })
+
+  test('should not return a result and have `isStatic: false` when the formula uses a non-pure formula ("randomNumber", "Now")', () => {
+    expect(
+      contextlessEvaluateFormula({
+        type: 'apply',
+        name: 'randomNumber',
+        arguments: [],
+      }),
+    ).toEqual({
+      isStatic: false,
+      result: undefined,
+    })
+
+    expect(
+      contextlessEvaluateFormula({
+        type: 'apply',
+        name: 'now',
+        arguments: [],
+      }),
+    ).toEqual({
+      isStatic: false,
+      result: undefined,
+    })
+  })
+
+  test('should not return a result and have `isStatic: false` when the formula depends on a variable', () => {
+    expect(
+      contextlessEvaluateFormula({
+        type: 'path',
+        path: ['Variables', 'myVariable'],
+      }),
+    ).toEqual({
+      isStatic: false,
+      result: undefined,
+    })
+  })
+
+  test('should return a result and static for an array formula where all args are array or value types', () => {
+    expect(
+      contextlessEvaluateFormula({
+        type: 'array',
+        arguments: [
+          { formula: { type: 'value', value: 1 } },
+          {
+            formula: {
+              type: 'array',
+              arguments: [{ formula: { type: 'value', value: 2 } }],
+            },
+          },
+        ],
+      }),
+    ).toEqual({
+      isStatic: true,
+      result: [1, [2]],
+    })
+  })
+
+  test('should return `isStatic: false` for an array formula with a non-static argument', () => {
+    expect(
+      contextlessEvaluateFormula({
+        type: 'array',
+        arguments: [
+          { formula: { type: 'value', value: 1 } },
+          { formula: { type: 'apply', name: 'randomNumber', arguments: [] } },
+        ],
+      }),
+    ).toEqual({
+      isStatic: false,
+      result: [
+        1,
+        undefined, // The second argument was not static
+      ],
+    })
+  })
+
+  test('should be static true for `And` formulas with no arguments', () => {
+    expect(
+      contextlessEvaluateFormula({
+        type: 'and',
+        arguments: [],
+      }),
+    ).toEqual({
+      isStatic: true,
+      result: true,
+    })
+  })
+
+  test('should be static false for `Or` formulas with no arguments', () => {
+    expect(
+      contextlessEvaluateFormula({
+        type: 'or',
+        arguments: [],
+      }),
+    ).toEqual({
+      isStatic: true,
+      result: false,
+    })
+  })
+
+  test('should be static true for `And` formulas with all static truthy arguments', () => {
+    expect(
+      contextlessEvaluateFormula({
+        type: 'and',
+        arguments: [
+          { formula: { type: 'value', value: true } },
+          { formula: { type: 'value', value: true } },
+        ],
+      }),
+    ).toEqual({
+      isStatic: true,
+      result: true,
+    })
+  })
+
+  test('should not be static for `And` where any dynamic value exist', () => {
+    expect(
+      contextlessEvaluateFormula({
+        type: 'and',
+        arguments: [
+          { formula: { type: 'value', value: true } },
+          { formula: { type: 'apply', name: 'randomNumber', arguments: [] } },
+        ],
+      }),
+    ).toEqual({
+      isStatic: false,
+      result: undefined,
+    })
+  })
+
+  test('should be static false for `And` when any argument is static false, even when dynamic arguments exist', () => {
+    expect(
+      contextlessEvaluateFormula({
+        type: 'and',
+        arguments: [
+          { formula: { type: 'value', value: true } },
+          { formula: { type: 'path', path: ['Variables', 'myVariable'] } },
+          { formula: { type: 'value', value: false } },
+        ],
+      }),
+    ).toEqual({
+      isStatic: true,
+      result: false,
+    })
+  })
+
+  test('should not be static for `Or` when any argument is dynamic and all static are falsy', () => {
+    expect(
+      contextlessEvaluateFormula({
+        type: 'or',
+        arguments: [
+          { formula: { type: 'value', value: false } },
+          { formula: { type: 'apply', name: 'randomNumber', arguments: [] } },
+        ],
+      }),
+    ).toEqual({
+      isStatic: false,
+      result: undefined,
+    })
+  })
+
+  test('should be static true for `Or` when any argument is static true, even when dynamic arguments exist', () => {
+    expect(
+      contextlessEvaluateFormula({
+        type: 'or',
+        arguments: [
+          { formula: { type: 'value', value: true } },
+          { formula: { type: 'apply', name: 'randomNumber', arguments: [] } },
+        ],
+      }),
+    ).toEqual({
+      isStatic: true,
+      result: true,
+    })
+  })
+})

--- a/packages/search/src/util/contextlessEvaluateFormula.ts
+++ b/packages/search/src/util/contextlessEvaluateFormula.ts
@@ -1,0 +1,111 @@
+import { type Formula } from '@nordcraft/core/dist/formula/formula'
+
+/**
+ * Static evaluation of a formula.
+ *
+ * Can be used by issues to determine if a formula or sub-formula can be reduced to a static value.
+ * When sophisticated enough, it can be used during compile-time to reduce all static subgraphs of a formula to static values, greatly reducing payload and improving runtime performance.
+ *
+ * @returns {
+ *  isStatic: boolean; // Whether the formula is static (i.e., does not depend on any variables, context AND only use pure formulas (no Random, Date, etc.))
+ *  result: unknown; // The evaluated value of the formula
+ * }
+ *
+ * TODO: Make this function more capable of evaluating pure core formulas.
+ * TODO: Memorize the results (using path or a fast hash) to avoid re-evaluating any similar sub-graphs multiple times.
+ * TODO: Add a complex test-suite to ensure it works and develops as expected.
+ */
+
+export const contextlessEvaluateFormula = (
+  formula: Formula,
+): {
+  isStatic: boolean
+  result: unknown
+} => {
+  // Very basic implementation, just to get started.
+  switch (formula.type) {
+    case 'value': {
+      return {
+        isStatic: true,
+        result: formula.value,
+      }
+    }
+
+    case 'array': {
+      const results = formula.arguments.map((arg) =>
+        contextlessEvaluateFormula(arg.formula),
+      )
+
+      return {
+        isStatic: results.every((res) => res.isStatic),
+        result: results.map((res) => res.result),
+      }
+    }
+
+    case 'record': {
+      const entries = Object.entries(formula.entries).map(
+        ([key, arg]) => [key, contextlessEvaluateFormula(arg.formula)] as const,
+      )
+
+      const results = entries.map(([, res]) => res)
+
+      return {
+        isStatic: results.every((res) => res.isStatic),
+        result: Object.fromEntries(
+          entries.map(([key, res]) => [key, res.result]),
+        ),
+      }
+    }
+
+    // Static if:
+    // - ALL conditions are static AND truthy
+    // - ANY condition is static and falsy
+    // - EMPTY argument list is always true
+    case 'and': {
+      const results = formula.arguments.map((arg) =>
+        contextlessEvaluateFormula(arg.formula),
+      )
+
+      const alwaysTrue =
+        results.length === 0 ||
+        results.every((res) => res.isStatic && Boolean(res.result) === true)
+      const alwaysFalsy = results.some(
+        (res) => res.isStatic && Boolean(res.result) === false,
+      )
+
+      return {
+        isStatic: alwaysTrue || alwaysFalsy,
+        result: alwaysTrue ? true : alwaysFalsy ? false : undefined,
+      }
+    }
+
+    // Static if:
+    // - ANY condition is static AND truthy
+    // - ALL conditions are static AND falsy
+    // - EMPTY argument list is always false
+    case 'or': {
+      const results = formula.arguments.map((arg) =>
+        contextlessEvaluateFormula(arg.formula),
+      )
+
+      const alwaysFalsy =
+        results.length === 0 ||
+        results.every((res) => res.isStatic && Boolean(res.result) === false)
+      const alwaysTrue = results.some(
+        (res) => res.isStatic && Boolean(res.result) === true,
+      )
+
+      return {
+        isStatic: alwaysTrue || alwaysFalsy,
+        result: alwaysFalsy ? false : alwaysTrue ? true : undefined,
+      }
+    }
+
+    default:
+      // For now, we assume that any other formula is not static.
+      return {
+        isStatic: false,
+        result: undefined,
+      }
+  }
+}

--- a/packages/search/src/util/contextlessEvaluateFormula.ts
+++ b/packages/search/src/util/contextlessEvaluateFormula.ts
@@ -12,10 +12,9 @@ import { type Formula } from '@nordcraft/core/dist/formula/formula'
  * }
  *
  * TODO: Make this function more capable of evaluating pure core formulas.
- * TODO: Memorize the results (using path or a fast hash) to avoid re-evaluating any similar sub-graphs multiple times.
+ * TODO: Memoize the results (using path or a fast hash) to avoid re-evaluating any similar sub-graphs multiple times.
  * TODO: Add a complex test-suite to ensure it works and develops as expected.
  */
-
 export const contextlessEvaluateFormula = (
   formula: Formula,
 ): {

--- a/packages/search/src/util/removeUnused.fix.ts
+++ b/packages/search/src/util/removeUnused.fix.ts
@@ -1,5 +1,33 @@
-import { omit } from '@nordcraft/core/dist/utils/collections'
+import type { NodeModel } from '@nordcraft/core/dist/component/component.types'
+import { get, omit, set } from '@nordcraft/core/dist/utils/collections'
 import type { FixFunction, NodeType } from '../types'
 
 export const removeFromPathFix: FixFunction<NodeType> = ({ path, files }) =>
   omit(files, path)
+
+/**
+ * Same as removeFromPathFix, but also removes the node from its parent's children.
+ */
+export const removeNodeFromPathFix: FixFunction<NodeType> = (data) => {
+  if (data.nodeType !== 'component-node') {
+    throw new Error('removeNodeFromPathFix can only be used on component nodes')
+  }
+
+  const componentNodesPath = data.path.slice(0, -1).map(String)
+  const filesWithoutNode = removeFromPathFix(data)
+  const nodes = get(filesWithoutNode, componentNodesPath) as Record<
+    string,
+    NodeModel
+  >
+  for (const key in nodes) {
+    if (
+      nodes[key].children?.includes(data.path[data.path.length - 1] as string)
+    ) {
+      nodes[key].children = nodes[key].children.filter(
+        (p) => p !== data.path[data.path.length - 1],
+      )
+    }
+  }
+
+  return set(filesWithoutNode, componentNodesPath, nodes)
+}


### PR DESCRIPTION
The whole static check is interesting in regards to compiler or pre-processing as well. It doesn't work with core formulas yet, but we would need to specifically flag each formula that is **pure**. For pure formulas, we should be able to run apply formula without any context like Variable or environment data.

Dunno if this idea is the way to go, but perhaps until we dive further down the rabbit hole this can help flag some project issues.