### PR TITLE
Adjust search worker to include an id in messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nordcraft",
   "type": "module",
   "license": "Apache-2.0",
-  "version": "1.0.45",
+  "version": "1.0.46",
   "homepage": "https://github.com/nordcraftengine/nordcraft",
   "private": "false",
   "workspaces": [


### PR DESCRIPTION
Including an id in messages (both requests and responses) allows the main thread to match responses to requests, which is especially useful when multiple requests are made concurrently. In our case, we both request problems for a single file and for the entire project.