### PR TITLE
Fix issue when removing node from path

### DIFF
--- a/packages/search/src/util/removeUnused.fix.ts
+++ b/packages/search/src/util/removeUnused.fix.ts
@@ -15,7 +15,10 @@ export const removeNodeFromPathFix: FixFunction<NodeType> = (data) => {
 
   const componentNodesPath = data.path.map(String)
   const nodeId = componentNodesPath.pop()!
-  const nodes = get(data.files, componentNodesPath) as Record<string, NodeModel>
+  const nodes = { ...get(data.files, componentNodesPath) } as Record<
+    string,
+    NodeModel
+  >
 
   // Clean parent reference
   for (const key in nodes) {


### PR DESCRIPTION
Since we're using `delete`, we should make sure we work on a copy of the original object. Otherwise, after applying a fix, the original object would have been mutated, and the diff would be empty.