### PR TITLE
Include asset override urls in preview backend

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -30,7 +30,7 @@
         "@cloudflare/workers-types": "4.20250628.0",
         "@nordcraft/runtime": "workspace:*",
         "@types/node": "24.3.1",
-        "wrangler": "4.37.0",
+        "wrangler": "4.37.1",
       },
     },
     "packages/core": {
@@ -86,15 +86,15 @@
 
     "@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.7.3", "", { "peerDependencies": { "unenv": "2.0.0-rc.21", "workerd": "^1.20250828.1" }, "optionalPeers": ["workerd"] }, "sha512-tsQQagBKjvpd9baa6nWVIv399ejiqcrUBBW6SZx6Z22+ymm+Odv5+cFimyuCsD/fC1fQTwfRmwXBNpzvHSeGCw=="],
 
-    "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20250906.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-E+X/YYH9BmX0ew2j/mAWFif2z05NMNuhCTlNYEGLkqMe99K15UewBqajL9pMcMUKxylnlrEoK3VNxl33DkbnPA=="],
+    "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20250913.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-926bBGIYDsF0FraaPQV0hO9LymEN+Zdkkm1qOHxU1c58oAxr5b9Tpe4d1z1EqOD0DTFhjn7V/AxKcZBaBBhO/A=="],
 
-    "@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20250906.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-X5apsZ1SFW4FYTM19ISHf8005FJMPfrcf4U5rO0tdj+TeJgQgXuZ57IG0WeW7SpLVeBo8hM6WC8CovZh41AfnA=="],
+    "@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20250913.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-uy5nJIt44CpICgfsKQotji31cn39i71e2KqE/zeAmmgYp/tzl2cXotVeDtynqqEsloox7hl/eBY5sU0x99N8oQ=="],
 
-    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20250906.0", "", { "os": "linux", "cpu": "x64" }, "sha512-rlKzWgsLnlQ5Nt9W69YBJKcmTmZbOGu0edUsenXPmc6wzULUxoQpi7ZE9k3TfTonJx4WoQsQlzCUamRYFsX+0Q=="],
+    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20250913.0", "", { "os": "linux", "cpu": "x64" }, "sha512-khdF7MBi8L9WIt3YyWBQxipMny0J3gG824kurZiRACZmPdQ1AOzkKybDDXC3EMcF8TmGMRqKRUGQIB/25PwJuQ=="],
 
-    "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20250906.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-DdedhiQ+SeLzpg7BpcLrIPEZ33QKioJQ1wvL4X7nuLzEB9rWzS37NNNahQzc1+44rhG4fyiHbXBPOeox4B9XVA=="],
+    "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20250913.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-KF5nIOt5YIYGfinY0YEe63JqaAx8WSFDHTLQpytTX+N/oJWEJu3KW6evU1TfX7o8gRlRsc0j/evcZ1vMfbDy5g=="],
 
-    "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20250906.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Q8Qjfs8jGVILnZL6vUpQ90q/8MTCYaGR3d1LGxZMBqte8Vr7xF3KFHPEy7tFs0j0mMjnqCYzlofmPNY+9ZaDRg=="],
+    "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20250913.0", "", { "os": "win32", "cpu": "x64" }, "sha512-m/PMnVdaUB7ymW8BvDIC5xrU16hBDCBpyf9/4y9YZSQOYTVXihxErX8kaW9H9A/I6PTX081NmxxhTbb/n+EQRg=="],
 
     "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20250628.0", "", {}, "sha512-V4HthfhtQU2vTpwLeUic8FTLgGSjglsGZMJc9jKBNYEU/k0A1rE55UgQoTb5blKQdGtpQKfVKs3FROeY/lXmbw=="],
 
@@ -480,7 +480,7 @@
 
     "mime": ["mime@3.0.0", "", { "bin": { "mime": "cli.js" } }, "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="],
 
-    "miniflare": ["miniflare@4.20250906.2", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "acorn": "8.14.0", "acorn-walk": "8.3.2", "exit-hook": "2.2.1", "glob-to-regexp": "0.4.1", "sharp": "^0.33.5", "stoppable": "1.1.0", "undici": "7.14.0", "workerd": "1.20250906.0", "ws": "8.18.0", "youch": "4.1.0-beta.10", "zod": "3.22.3" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-SXGv8Rdd91b6UXZ5eW3rde/gSJM6WVLItMNFV7u9axUVhACvpT4CB5p80OBfi2OOsGfOuFQ6M6s8tMxJbzioVw=="],
+    "miniflare": ["miniflare@4.20250913.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "acorn": "8.14.0", "acorn-walk": "8.3.2", "exit-hook": "2.2.1", "glob-to-regexp": "0.4.1", "sharp": "^0.33.5", "stoppable": "1.1.0", "undici": "7.14.0", "workerd": "1.20250913.0", "ws": "8.18.0", "youch": "4.1.0-beta.10", "zod": "3.22.3" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-EwlUOxtvb9UKg797YZMCtNga/VSAnKG/kbJX9YGqXJoAJjDhDeAeqyCWjSl9O6EzCZNhtHuW7ZV0pD5Hec617g=="],
 
     "minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
@@ -578,9 +578,9 @@
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
-    "workerd": ["workerd@1.20250906.0", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20250906.0", "@cloudflare/workerd-darwin-arm64": "1.20250906.0", "@cloudflare/workerd-linux-64": "1.20250906.0", "@cloudflare/workerd-linux-arm64": "1.20250906.0", "@cloudflare/workerd-windows-64": "1.20250906.0" }, "bin": { "workerd": "bin/workerd" } }, "sha512-ryVyEaqXPPsr/AxccRmYZZmDAkfQVjhfRqrNTlEeN8aftBk6Ca1u7/VqmfOayjCXrA+O547TauebU+J3IpvFXw=="],
+    "workerd": ["workerd@1.20250913.0", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20250913.0", "@cloudflare/workerd-darwin-arm64": "1.20250913.0", "@cloudflare/workerd-linux-64": "1.20250913.0", "@cloudflare/workerd-linux-arm64": "1.20250913.0", "@cloudflare/workerd-windows-64": "1.20250913.0" }, "bin": { "workerd": "bin/workerd" } }, "sha512-y3J1NjCL10SAWDwgGdcNSRyOVod/dWNypu64CCdjj8VS4/k+Ofa/fHaJGC1stbdzAB1tY2P35Ckgm1PU5HKWiw=="],
 
-    "wrangler": ["wrangler@4.37.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.0", "@cloudflare/unenv-preset": "2.7.3", "blake3-wasm": "2.1.5", "esbuild": "0.25.4", "miniflare": "4.20250906.2", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.21", "workerd": "1.20250906.0" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20250906.0" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-W8IbQohQbUHFn4Hz2kh8gi0SdyFV/jyi9Uus+WrTz0F0Dc9W5qKPCjLbxibeE53+YPHyoI25l65O7nSlwX+Z6Q=="],
+    "wrangler": ["wrangler@4.37.1", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.0", "@cloudflare/unenv-preset": "2.7.3", "blake3-wasm": "2.1.5", "esbuild": "0.25.4", "miniflare": "4.20250913.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.21", "workerd": "1.20250913.0" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20250913.0" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-ntm1OsIB2r/f7b5bfS84Lzz5QEx3zn4vUsn1JOVz/+7bw8triyytnxbp68OwOimF1vL5A9sQ0Nd+L6u8F3hECg=="],
 
     "ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -30,7 +30,7 @@
         "@cloudflare/workers-types": "4.20250628.0",
         "@nordcraft/runtime": "workspace:*",
         "@types/node": "24.3.1",
-        "wrangler": "4.24.1",
+        "wrangler": "4.37.0",
       },
     },
     "packages/core": {
@@ -84,17 +84,17 @@
   "packages": {
     "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.4.0", "", { "dependencies": { "mime": "^3.0.0" } }, "sha512-+tv3z+SPp+gqTIcImN9o0hqE9xyfQjI1XD9pL6NuKjua9B1y7mNYv0S9cP+QEbA4ppVgGZEmKOvHX5G5Ei1CVA=="],
 
-    "@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.3.3", "", { "peerDependencies": { "unenv": "2.0.0-rc.17", "workerd": "^1.20250508.0" }, "optionalPeers": ["workerd"] }, "sha512-/M3MEcj3V2WHIRSW1eAQBPRJ6JnGQHc6JKMAPLkDb7pLs3m6X9ES/+K3ceGqxI6TKeF32AWAi7ls0AYzVxCP0A=="],
+    "@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.7.3", "", { "peerDependencies": { "unenv": "2.0.0-rc.21", "workerd": "^1.20250828.1" }, "optionalPeers": ["workerd"] }, "sha512-tsQQagBKjvpd9baa6nWVIv399ejiqcrUBBW6SZx6Z22+ymm+Odv5+cFimyuCsD/fC1fQTwfRmwXBNpzvHSeGCw=="],
 
-    "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20250709.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-VqwcvnbI8FNCP87ZWNHA3/sAC5U9wMbNnjBG0sHEYzM7B9RPHKYHdVKdBEWhzZXnkQYMK81IHm4CZsK16XxAuQ=="],
+    "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20250906.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-E+X/YYH9BmX0ew2j/mAWFif2z05NMNuhCTlNYEGLkqMe99K15UewBqajL9pMcMUKxylnlrEoK3VNxl33DkbnPA=="],
 
-    "@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20250709.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-A54ttSgXMM4huChPTThhkieOjpDxR+srVOO9zjTHVIyoQxA8zVsku4CcY/GQ95RczMV+yCKVVu/tAME7vwBFuA=="],
+    "@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20250906.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-X5apsZ1SFW4FYTM19ISHf8005FJMPfrcf4U5rO0tdj+TeJgQgXuZ57IG0WeW7SpLVeBo8hM6WC8CovZh41AfnA=="],
 
-    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20250709.0", "", { "os": "linux", "cpu": "x64" }, "sha512-no4O3OK+VXINIxv99OHJDpIgML2ZssrSvImwLtULzqm+cl4t1PIfXNRUqj89ujTkmad+L9y4G6dBQMPCLnmlGg=="],
+    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20250906.0", "", { "os": "linux", "cpu": "x64" }, "sha512-rlKzWgsLnlQ5Nt9W69YBJKcmTmZbOGu0edUsenXPmc6wzULUxoQpi7ZE9k3TfTonJx4WoQsQlzCUamRYFsX+0Q=="],
 
-    "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20250709.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-7cNICk2Qd+m4QGrcmWyAuZJXTHt1ud6isA+dic7Yk42WZmwXhlcUATyvFD9FSQNFcldjuRB4n8JlWEFqZBn+lw=="],
+    "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20250906.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-DdedhiQ+SeLzpg7BpcLrIPEZ33QKioJQ1wvL4X7nuLzEB9rWzS37NNNahQzc1+44rhG4fyiHbXBPOeox4B9XVA=="],
 
-    "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20250709.0", "", { "os": "win32", "cpu": "x64" }, "sha512-j1AyO8V/62Q23EJplWgzBlRCqo/diXgox58AbDqSqgyzCBAlvUzXQRDBab/FPNG/erRqt7I1zQhahrBhrM0uLA=="],
+    "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20250906.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Q8Qjfs8jGVILnZL6vUpQ90q/8MTCYaGR3d1LGxZMBqte8Vr7xF3KFHPEy7tFs0j0mMjnqCYzlofmPNY+9ZaDRg=="],
 
     "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20250628.0", "", {}, "sha512-V4HthfhtQU2vTpwLeUic8FTLgGSjglsGZMJc9jKBNYEU/k0A1rE55UgQoTb5blKQdGtpQKfVKs3FROeY/lXmbw=="],
 
@@ -171,8 +171,6 @@
     "@eslint/object-schema": ["@eslint/object-schema@2.1.6", "", {}, "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA=="],
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.3.3", "", { "dependencies": { "@eslint/core": "^0.15.1", "levn": "^0.4.1" } }, "sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag=="],
-
-    "@fastify/busboy": ["@fastify/busboy@2.1.1", "", {}, "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="],
 
     "@happy-dom/global-registrator": ["@happy-dom/global-registrator@18.0.1", "", { "dependencies": { "@types/node": "^20.0.0", "happy-dom": "^18.0.1" } }, "sha512-xCy/cpEP8xyJ6u0eokYgaQxeUmcKqHx/+aC3R0DLa7/S38efhZAVDQqLJ5zzTguLFS0gvAzZHP40NGaLwRyapQ=="],
 
@@ -482,7 +480,7 @@
 
     "mime": ["mime@3.0.0", "", { "bin": { "mime": "cli.js" } }, "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="],
 
-    "miniflare": ["miniflare@4.20250709.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "acorn": "8.14.0", "acorn-walk": "8.3.2", "exit-hook": "2.2.1", "glob-to-regexp": "0.4.1", "sharp": "^0.33.5", "stoppable": "1.1.0", "undici": "^5.28.5", "workerd": "1.20250709.0", "ws": "8.18.0", "youch": "4.1.0-beta.10", "zod": "3.22.3" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-dRGXi6Do9ArQZt7205QGWZ1tD6k6xQNY/mAZBAtiaQYvKxFuNyiHYlFnSN8Co4AFCVOozo/U52sVAaHvlcmnew=="],
+    "miniflare": ["miniflare@4.20250906.2", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "acorn": "8.14.0", "acorn-walk": "8.3.2", "exit-hook": "2.2.1", "glob-to-regexp": "0.4.1", "sharp": "^0.33.5", "stoppable": "1.1.0", "undici": "7.14.0", "workerd": "1.20250906.0", "ws": "8.18.0", "youch": "4.1.0-beta.10", "zod": "3.22.3" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-SXGv8Rdd91b6UXZ5eW3rde/gSJM6WVLItMNFV7u9axUVhACvpT4CB5p80OBfi2OOsGfOuFQ6M6s8tMxJbzioVw=="],
 
     "minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
@@ -564,11 +562,11 @@
 
     "ufo": ["ufo@1.6.1", "", {}, "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA=="],
 
-    "undici": ["undici@5.29.0", "", { "dependencies": { "@fastify/busboy": "^2.0.0" } }, "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg=="],
+    "undici": ["undici@7.14.0", "", {}, "sha512-Vqs8HTzjpQXZeXdpsfChQTlafcMQaaIwnGwLam1wudSSjlJeQ3bw1j+TLPePgrCnCpUXx7Ba5Pdpf5OBih62NQ=="],
 
     "undici-types": ["undici-types@7.10.0", "", {}, "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag=="],
 
-    "unenv": ["unenv@2.0.0-rc.17", "", { "dependencies": { "defu": "^6.1.4", "exsolve": "^1.0.4", "ohash": "^2.0.11", "pathe": "^2.0.3", "ufo": "^1.6.1" } }, "sha512-B06u0wXkEd+o5gOCMl/ZHl5cfpYbDZKAT+HWTL+Hws6jWu7dCiqBBXXXzMFcFVJb8D4ytAnYmxJA83uwOQRSsg=="],
+    "unenv": ["unenv@2.0.0-rc.21", "", { "dependencies": { "defu": "^6.1.4", "exsolve": "^1.0.7", "ohash": "^2.0.11", "pathe": "^2.0.3", "ufo": "^1.6.1" } }, "sha512-Wj7/AMtE9MRnAXa6Su3Lk0LNCfqDYgfwVjwRFVum9U7wsto1imuHqk4kTm7Jni+5A0Hn7dttL6O/zjvUvoo+8A=="],
 
     "universal-user-agent": ["universal-user-agent@7.0.3", "", {}, "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="],
 
@@ -580,9 +578,9 @@
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
-    "workerd": ["workerd@1.20250709.0", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20250709.0", "@cloudflare/workerd-darwin-arm64": "1.20250709.0", "@cloudflare/workerd-linux-64": "1.20250709.0", "@cloudflare/workerd-linux-arm64": "1.20250709.0", "@cloudflare/workerd-windows-64": "1.20250709.0" }, "bin": { "workerd": "bin/workerd" } }, "sha512-BqLPpmvRN+TYUSG61OkWamsGdEuMwgvabP8m0QOHIfofnrD2YVyWqE1kXJ0GH5EsVEuWamE5sR8XpTfsGBmIpg=="],
+    "workerd": ["workerd@1.20250906.0", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20250906.0", "@cloudflare/workerd-darwin-arm64": "1.20250906.0", "@cloudflare/workerd-linux-64": "1.20250906.0", "@cloudflare/workerd-linux-arm64": "1.20250906.0", "@cloudflare/workerd-windows-64": "1.20250906.0" }, "bin": { "workerd": "bin/workerd" } }, "sha512-ryVyEaqXPPsr/AxccRmYZZmDAkfQVjhfRqrNTlEeN8aftBk6Ca1u7/VqmfOayjCXrA+O547TauebU+J3IpvFXw=="],
 
-    "wrangler": ["wrangler@4.24.1", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.0", "@cloudflare/unenv-preset": "2.3.3", "blake3-wasm": "2.1.5", "esbuild": "0.25.4", "miniflare": "4.20250709.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.17", "workerd": "1.20250709.0" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20250709.0" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-n7d5BQyOQU7WyEYMC3zNarWzsqWttsusP6qWz4rbbydmnWKSP1wLtsv0yKiyz/LYFumpolz48d5phHp04nR6uw=="],
+    "wrangler": ["wrangler@4.37.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.0", "@cloudflare/unenv-preset": "2.7.3", "blake3-wasm": "2.1.5", "esbuild": "0.25.4", "miniflare": "4.20250906.2", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.21", "workerd": "1.20250906.0" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20250906.0" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-W8IbQohQbUHFn4Hz2kh8gi0SdyFV/jyi9Uus+WrTz0F0Dc9W5qKPCjLbxibeE53+YPHyoI25l65O7nSlwX+Z6Q=="],
 
     "ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
 

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -15,6 +15,7 @@
     "test:watch": "bun test --watch",
     "test:watch:only": "bun test --watch --only",
     "typecheck": "tsc --noEmit",
+    "typecheck:watch": "tsc --noEmit --watch",
     "watch": "tsc --noEmit -w"
   },
   "dependencies": {
@@ -26,6 +27,6 @@
     "@cloudflare/workers-types": "4.20250628.0",
     "@nordcraft/runtime": "workspace:*",
     "@types/node": "24.3.1",
-    "wrangler": "4.24.1"
+    "wrangler": "4.37.0"
   }
 }

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -27,6 +27,6 @@
     "@cloudflare/workers-types": "4.20250628.0",
     "@nordcraft/runtime": "workspace:*",
     "@types/node": "24.3.1",
-    "wrangler": "4.37.0"
+    "wrangler": "4.37.1"
   }
 }

--- a/packages/backend/preview.wrangler.toml
+++ b/packages/backend/preview.wrangler.toml
@@ -2,7 +2,7 @@
 name = "nordcraft-worker-preview"
 
 main = "src/preview.index.ts"
-compatibility_date = "2025-09-02"
+compatibility_date = "2025-09-13"
 
 [observability.logs]
 enabled = true

--- a/packages/backend/preview.wrangler.toml
+++ b/packages/backend/preview.wrangler.toml
@@ -2,7 +2,7 @@
 name = "nordcraft-worker-preview"
 
 main = "src/preview.index.ts"
-compatibility_date = "2025-07-08"
+compatibility_date = "2025-09-02"
 
 [observability.logs]
 enabled = true

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -2,7 +2,7 @@ import { initIsEqual } from '@nordcraft/ssr/dist/rendering/equals'
 import { Hono, type Handler, type MiddlewareHandler } from 'hono'
 import { poweredBy } from 'hono/powered-by'
 import type { HonoEnv } from '../hono'
-import type { PageLoader } from './loaders/types'
+import type { PageLoader, PageLoaderUrls } from './loaders/types'
 import { notFoundLoader } from './middleware/notFoundLoader'
 import { proxyRequestHandler } from './routes/apiProxy'
 import { setCookieHandler } from './routes/cookies'
@@ -20,7 +20,10 @@ export const getApp = <T extends Record<string, any>>(options: {
   staticRouter?: { path: string; handler: Handler }
   stylesheetRouter?: { path: string; handler: Handler }
   customCodeRouter?: { path: string; handler: Handler }
-  pageLoader: PageLoader
+  pageLoader: {
+    loader: PageLoader
+    urls: PageLoaderUrls
+  }
   fileLoaders: MiddlewareHandler[]
 }) => {
   // Inject isEqual on globalThis used by some builtin formulas
@@ -66,9 +69,11 @@ export const getApp = <T extends Record<string, any>>(options: {
   app.get('/serviceWorker.js', serviceWorker)
 
   // Load a page if it matches the URL
-  app.get('/*', pageHandler(options.pageLoader))
+  app.get('/*', pageHandler(options.pageLoader.loader, options.pageLoader.urls))
 
-  app.notFound(notFoundLoader(options.pageLoader) as any)
+  app.notFound(
+    notFoundLoader(options.pageLoader.loader, options.pageLoader.urls) as any,
+  )
 
   return app
 }

--- a/packages/backend/src/bun.index.ts
+++ b/packages/backend/src/bun.index.ts
@@ -11,8 +11,14 @@ const app = getApp({
     path: '/_static/*',
     handler: serveStatic({ root: './assets' }),
   },
-  pageLoader: ({ name }) =>
-    loadJsFile<ProjectFilesWithCustomCode>(`./components/${name}.js`),
+  pageLoader: {
+    loader: ({ name }) =>
+      loadJsFile<ProjectFilesWithCustomCode>(`./components/${name}.js`),
+    urls: {
+      pageStylesheetUrl: (name) => `/_static/${name}}.css`,
+      customCodeUrl: (name) => `/_static/cc_${name}.js`,
+    },
+  },
 })
 
 export default app

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -6,8 +6,14 @@ import { routesLoader } from './middleware/routesLoader'
 
 const app = getApp({
   fileLoaders: [routesLoader, loadProjectInfo],
-  pageLoader: ({ name }) =>
-    loadJsFile<ProjectFilesWithCustomCode>(`./components/${name}.js`),
+  pageLoader: {
+    loader: ({ name }) =>
+      loadJsFile<ProjectFilesWithCustomCode>(`./components/${name}.js`),
+    urls: {
+      pageStylesheetUrl: (name) => `/_static/${name}}.css`,
+      customCodeUrl: (name) => `/_static/cc_${name}.js`,
+    },
+  },
 })
 
 export default app

--- a/packages/backend/src/loaders/types.d.ts
+++ b/packages/backend/src/loaders/types.d.ts
@@ -10,3 +10,8 @@ export type PageLoader<T = any> = ({
   name: string
   ctx: Context<HonoEnv<T>>
 }) => MaybePromise<(ProjectFiles & { customCode: boolean }) | undefined>
+
+export interface PageLoaderUrls {
+  pageStylesheetUrl: (name: string) => string
+  customCodeUrl: (name: string) => string
+}

--- a/packages/backend/src/middleware/notFoundLoader.ts
+++ b/packages/backend/src/middleware/notFoundLoader.ts
@@ -1,13 +1,14 @@
 import { isPageComponent } from '@nordcraft/core/dist/component/isPageComponent'
 import type { NotFoundHandler } from 'hono'
 import type { HonoEnv, HonoProject, HonoRoutes } from '../../hono'
-import type { PageLoader } from '../loaders/types'
+import type { PageLoader, PageLoaderUrls } from '../loaders/types'
 import { nordcraftPage } from '../routes/nordcraftPage'
 
 export const notFoundLoader: (
   pageLoader: PageLoader,
+  options: PageLoaderUrls,
 ) => NotFoundHandler<HonoEnv<HonoRoutes & HonoProject>> =
-  (pageLoader) => async (ctx) => {
+  (pageLoader, options) => async (ctx) => {
     const pageContent = await pageLoader({ ctx, name: '404' })
     const component = pageContent?.components?.['404']
     if (!component || !isPageComponent(component)) {
@@ -21,5 +22,6 @@ export const notFoundLoader: (
       files: pageContent,
       page: component,
       status: 404,
+      options,
     })
   }

--- a/packages/backend/src/preview.index.ts
+++ b/packages/backend/src/preview.index.ts
@@ -15,8 +15,14 @@ const app = getApp({
     path: '/.toddle/custom-code/:pageName{.+.js}',
     handler: customCode,
   },
-  pageLoader: ({ ctx }) => {
-    return { customCode: true, ...ctx.get('files') }
+  pageLoader: {
+    loader: ({ ctx }) => {
+      return { customCode: true, ...ctx.get('files') }
+    },
+    urls: {
+      pageStylesheetUrl: (name: string) => `/.toddle/stylesheet/${name}.css`,
+      customCodeUrl: (name: string) => `/.toddle/custom-code/${name}.js`,
+    },
   },
   fileLoaders: [
     createMiddleware<

--- a/packages/backend/src/routes/nordcraftPage.ts
+++ b/packages/backend/src/routes/nordcraftPage.ts
@@ -23,6 +23,7 @@ import type { Context } from 'hono'
 import { html, raw } from 'hono/html'
 import type { ContentfulStatusCode } from 'hono/utils/http-status'
 import type { HonoEnv } from '../../hono'
+import type { PageLoaderUrls } from '../loaders/types'
 import { evaluateComponentApis, RedirectError } from '../utils/api'
 
 export const nordcraftPage = async ({
@@ -38,10 +39,7 @@ export const nordcraftPage = async ({
   files: ProjectFiles & { customCode: boolean }
   page: PageComponent
   status: ContentfulStatusCode
-  options?: {
-    pageStylesheetUrl?: (name: string) => string
-    customCodeUrl?: (name: string) => string
-  }
+  options: PageLoaderUrls
 }) => {
   const url = new URL(hono.req.raw.url)
   const formulaContext = getPageFormulaContext({
@@ -127,9 +125,7 @@ export const nordcraftPage = async ({
       // Just to be explicit about where to grab the reset stylesheet from
       resetStylesheetPath: '/_static/reset.css',
       // This refers to the generated stylesheet for each page
-      pageStylesheetPath: options?.pageStylesheetUrl
-        ? options.pageStylesheetUrl(page.name)
-        : `/_static/${page.name}.css`,
+      pageStylesheetPath: options.pageStylesheetUrl(page.name),
       page: toddleComponent,
       files: files,
       project,
@@ -170,8 +166,7 @@ export const nordcraftPage = async ({
             </script>
             <script type="module">
               import { initGlobalObject, createRoot } from '/_static/page.main.esm.js';
-              import { loadCustomCode, formulas, actions } from '${options?.customCodeUrl ? options.customCodeUrl(toddleComponent.name) : `/_static/cc_${toddleComponent.name}.js`}'
-
+              import { loadCustomCode, formulas, actions } from '${options.customCodeUrl(toddleComponent.name)}'
               window.__toddle = JSON.parse(document.getElementById('nordcraft-data').textContent);
               window.__toddle.components = [window.__toddle.component, ...window.__toddle.components];
               initGlobalObject({formulas, actions});

--- a/packages/backend/src/routes/pageHandler.ts
+++ b/packages/backend/src/routes/pageHandler.ts
@@ -2,15 +2,12 @@ import { isPageComponent } from '@nordcraft/core/dist/component/isPageComponent'
 import { matchPageForUrl } from '@nordcraft/ssr/dist/routing/routing'
 import type { MiddlewareHandler } from 'hono'
 import type { HonoEnv, HonoProject, HonoRoutes } from '../../hono'
-import type { PageLoader } from '../loaders/types'
+import type { PageLoader, PageLoaderUrls } from '../loaders/types'
 import { nordcraftPage } from './nordcraftPage'
 
 export const pageHandler: (
   pageLoader: PageLoader,
-  options?: {
-    pageStylesheetUrl?: (name: string) => string
-    customCodeUrl?: (name: string) => string
-  },
+  options: PageLoaderUrls,
 ) => MiddlewareHandler<HonoEnv<HonoRoutes & HonoProject>> =
   (pageLoader, options) => async (ctx, next) => {
     const url = new URL(ctx.req.url)

--- a/packages/backend/wrangler.toml
+++ b/packages/backend/wrangler.toml
@@ -2,7 +2,7 @@
 name = "nordcraft-worker-example"
 
 main = "dist/index.js"
-compatibility_date = "2025-07-08"
+compatibility_date = "2025-09-02"
 
 rules = [
   # Include all json files in the worker (should only be the actual project)

--- a/packages/backend/wrangler.toml
+++ b/packages/backend/wrangler.toml
@@ -2,7 +2,7 @@
 name = "nordcraft-worker-example"
 
 main = "dist/index.js"
-compatibility_date = "2025-09-02"
+compatibility_date = "2025-09-13"
 
 rules = [
   # Include all json files in the worker (should only be the actual project)


### PR DESCRIPTION
The stylesheet and custom code urls for (experimental) preview pages were not being set, causing 404s when trying to load the assets.
The urls are now required when using the shared Hono app in `app.ts`

This also bumps wrangler.