### PR TITLE
Fixed a bug where videos responses would be parsed as text

### DIFF
--- a/packages/core/src/api/headers.ts
+++ b/packages/core/src/api/headers.ts
@@ -40,6 +40,13 @@ export const isImageHeader = (header?: string | null) => {
   return /^image\//.test(header)
 }
 
+export const isVideoHeader = (header?: string | null) => {
+  if (typeof header !== 'string') {
+    return false
+  }
+  return /^video\//.test(header)
+}
+
 /**
  * Returns an object with headers from a Headers object
  * Duplicate header values (set-cookie for instance) are encoded as a comma-separated string

--- a/packages/runtime/src/api/createAPIv2.ts
+++ b/packages/runtime/src/api/createAPIv2.ts
@@ -17,6 +17,7 @@ import {
   isJsonHeader,
   isJsonStreamHeader,
   isTextHeader,
+  isVideoHeader,
   mapHeadersToObject,
 } from '@nordcraft/core/dist/api/headers'
 import type { ComponentData } from '@nordcraft/core/dist/component/component.types'
@@ -495,7 +496,7 @@ export function createAPI({
         parserMode = 'text'
       } else if (isJsonStreamHeader(contentType)) {
         parserMode = 'json-stream'
-      } else if (isImageHeader(contentType)) {
+      } else if (isImageHeader(contentType) || isVideoHeader(contentType)) {
         parserMode = 'blob'
       } else {
         parserMode = 'text'


### PR DESCRIPTION
If an API requests a video file, that file would be parsed as text. This is a very heavy operation and would slow performance down to an unusable level. This PR will ensure we automatically parse videos as blobs instead.