### PR TITLE
Add issue rule for unused API services

### DIFF
--- a/packages/search/src/problems.worker.ts
+++ b/packages/search/src/problems.worker.ts
@@ -8,6 +8,7 @@ import { noReferenceProjectActionRule } from './rules/actions/noReferenceProject
 import { unknownProjectActionRule } from './rules/actions/unknownProjectActionRule'
 import { legacyApiRule } from './rules/apis/legacyApiRule'
 import { noReferenceApiRule } from './rules/apis/noReferenceApiRule'
+import { noReferenceApiServiceRule } from './rules/apis/noReferenceApiServiceRule'
 import { unknownApiInputRule } from './rules/apis/unknownApiInputRule'
 import { unknownApiRule } from './rules/apis/unknownApiRule'
 import { noReferenceAttributeRule } from './rules/attributes/noReferenceAttributeRule'
@@ -155,6 +156,7 @@ const RULES = [
   nonEmptyVoidElementRule,
   noPostNavigateAction,
   noReferenceApiRule,
+  noReferenceApiServiceRule,
   noReferenceAttributeRule,
   noReferenceComponentFormulaRule,
   noReferenceComponentRule,

--- a/packages/search/src/rules/apis/noReferenceApiServiceRule.test.ts
+++ b/packages/search/src/rules/apis/noReferenceApiServiceRule.test.ts
@@ -1,0 +1,103 @@
+import { valueFormula } from '@nordcraft/core/dist/formula/formulaUtils'
+import type { ProjectFiles } from '@nordcraft/ssr/dist/ssr.types'
+import { describe, expect, test } from 'bun:test'
+import { fixProject } from '../../fixProject'
+import { searchProject } from '../../searchProject'
+import { noReferenceApiServiceRule } from './noReferenceApiServiceRule'
+
+describe('find noReferenceApiServiceRule', () => {
+  test('should detect API services with no references', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          formulas: {},
+          services: {
+            'unused-service': {
+              name: 'my-service',
+              type: 'supabase',
+              meta: {},
+            },
+            'used-service': {
+              name: 'used-service',
+              type: 'supabase',
+              meta: {},
+            },
+          },
+          components: {
+            apiComponent: {
+              name: 'test',
+              nodes: {},
+              formulas: {},
+              apis: {
+                'my-api': {
+                  name: 'my-api',
+                  type: 'http',
+                  version: 2,
+                  autoFetch: valueFormula(true),
+                  inputs: {},
+                  service: 'used-service',
+                },
+              },
+              attributes: {},
+              variables: {},
+            },
+          },
+        },
+        rules: [noReferenceApiServiceRule],
+      }),
+    )
+
+    expect(problems).toHaveLength(1)
+    expect(problems[0].code).toBe('no-reference api service')
+    expect(problems[0].path).toEqual(['services', 'unused-service'])
+  })
+})
+
+describe('fix noReferenceApiServiceRule', () => {
+  test('should remove unused API services', () => {
+    const project: ProjectFiles = {
+      formulas: {},
+      services: {
+        'unused-service': {
+          name: 'my-service',
+          type: 'supabase',
+          meta: {},
+        },
+        'used-service': {
+          name: 'used-service',
+          type: 'supabase',
+          meta: {},
+        },
+      },
+      components: {
+        apiComponent: {
+          name: 'test',
+          nodes: {},
+          formulas: {},
+          apis: {
+            'my-api': {
+              name: 'my-api',
+              type: 'http',
+              version: 2,
+              autoFetch: valueFormula(true),
+              inputs: {},
+              service: 'used-service',
+            },
+          },
+          onLoad: {
+            trigger: 'onLoad',
+            actions: [],
+          },
+          attributes: {},
+          variables: {},
+        },
+      },
+    }
+    const fixedProject = fixProject({
+      files: project,
+      rule: noReferenceApiServiceRule,
+      fixType: 'delete-api-service',
+    })
+    expect(Object.keys(fixedProject.services!)).toHaveLength(1)
+  })
+})

--- a/packages/search/src/rules/apis/noReferenceApiServiceRule.ts
+++ b/packages/search/src/rules/apis/noReferenceApiServiceRule.ts
@@ -1,0 +1,43 @@
+import { isLegacyApi } from '@nordcraft/core/dist/api/api'
+import type { Rule } from '../../types'
+import { removeFromPathFix } from '../../util/removeUnused.fix'
+
+export const noReferenceApiServiceRule: Rule<{ serviceName: string }> = {
+  code: 'no-reference api service',
+  level: 'warning',
+  category: 'No References',
+  visit: (report, args) => {
+    if (args.nodeType !== 'api-service') {
+      return
+    }
+    const { value, memo, path } = args
+    const serviceName = path.at(-1)
+    if (typeof serviceName !== 'string') {
+      return
+    }
+
+    const apiServiceReferences = memo(`apiServiceReferences`, () => {
+      const usedServices = new Set<string>()
+      Object.values(args.files.components).forEach((component) => {
+        if (!component) {
+          return
+        }
+        Object.values(component.apis).forEach((api) => {
+          if (!isLegacyApi(api) && typeof api.service === 'string') {
+            usedServices.add(api.service)
+          }
+        })
+      })
+      return usedServices
+    })
+    if (apiServiceReferences.has(value.name)) {
+      return
+    }
+    report(args.path, { serviceName }, ['delete-api-service'])
+  },
+  fixes: {
+    'delete-api-service': removeFromPathFix,
+  },
+}
+
+export type NoReferenceApiServiceRuleFix = 'delete-api-service'

--- a/packages/search/src/types.d.ts
+++ b/packages/search/src/types.d.ts
@@ -25,6 +25,7 @@ import type {
 import type { LegacyActionRuleFix } from './rules/actions/legacyActionRule'
 import type { NoReferenceProjectActionRuleFix } from './rules/actions/noReferenceProjectActionRule'
 import type { NoReferenceApiRuleFix } from './rules/apis/noReferenceApiRule'
+import type { NoReferenceApiServiceRuleFix } from './rules/apis/noReferenceApiServiceRule'
 import type { NoReferenceAttributeRuleFix } from './rules/attributes/noReferenceAttributeRule'
 import type { UnknownComponentAttributeRuleFix } from './rules/attributes/unknownComponentAttributeRule'
 import type { NoReferenceComponentRuleFix } from './rules/components/noReferenceComponentRule'
@@ -54,6 +55,7 @@ type Code =
   | 'no-console'
   | 'no-reference api input'
   | 'no-reference api'
+  | 'no-reference api service'
   | 'no-reference attribute'
   | 'no-reference component formula'
   | 'no-reference component workflow'
@@ -355,6 +357,7 @@ type FixType =
   | NoReferenceProjectFormulaRuleFix
   | NoReferenceProjectActionRuleFix
   | NoReferenceApiRuleFix
+  | NoReferenceApiServiceRuleFix
   | NoReferenceAttributeRuleFix
   | NoReferenceEventRuleFix
   | NoReferenceComponentFormulaRuleFix


### PR DESCRIPTION
This rule will find and potentially fix API services that are not referenced by any API.