### PR TITLE
Add unknownApiServiceRule for broken service refs

### DIFF
--- a/packages/search/src/problems.worker.ts
+++ b/packages/search/src/problems.worker.ts
@@ -11,6 +11,7 @@ import { noReferenceApiRule } from './rules/apis/noReferenceApiRule'
 import { noReferenceApiServiceRule } from './rules/apis/noReferenceApiServiceRule'
 import { unknownApiInputRule } from './rules/apis/unknownApiInputRule'
 import { unknownApiRule } from './rules/apis/unknownApiRule'
+import { unknownApiServiceRule } from './rules/apis/unknownApiServiceRule'
 import { noReferenceAttributeRule } from './rules/attributes/noReferenceAttributeRule'
 import { unknownAttributeRule } from './rules/attributes/unknownAttributeRule'
 import { unknownComponentAttributeRule } from './rules/attributes/unknownComponentAttributeRule'
@@ -170,8 +171,9 @@ const RULES = [
   noUnnecessaryConditionFalsy,
   noUnnecessaryConditionTruthy,
   requireExtensionRule,
-  unknownApiRule,
   unknownApiInputRule,
+  unknownApiRule,
+  unknownApiServiceRule,
   unknownAttributeRule,
   unknownClassnameRule,
   // unknownComponentFormulaInputRule,

--- a/packages/search/src/rules/apis/unknownApiServiceRule.test.ts
+++ b/packages/search/src/rules/apis/unknownApiServiceRule.test.ts
@@ -1,0 +1,152 @@
+import type { ApiRequest } from '@nordcraft/core/dist/api/apiTypes'
+import { valueFormula } from '@nordcraft/core/dist/formula/formulaUtils'
+import type { ProjectFiles } from '@nordcraft/ssr/dist/ssr.types'
+import { describe, expect, test } from 'bun:test'
+import { fixProject } from '../../fixProject'
+import { searchProject } from '../../searchProject'
+import { unknownApiServiceRule } from './unknownApiServiceRule'
+
+describe('find unknownApiServiceRule', () => {
+  test('should detect references to unknown services', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          formulas: {},
+          services: {
+            'used-service': {
+              name: 'used-service',
+              type: 'supabase',
+              meta: {},
+            },
+          },
+          components: {
+            apiComponent: {
+              name: 'test',
+              nodes: {},
+              formulas: {},
+              apis: {
+                'my-api': {
+                  name: 'my-api',
+                  type: 'http',
+                  version: 2,
+                  autoFetch: valueFormula(true),
+                  inputs: {},
+                  service: 'used-service',
+                },
+                'my-other-api': {
+                  name: 'my-other-api',
+                  type: 'http',
+                  version: 2,
+                  autoFetch: valueFormula(true),
+                  inputs: {},
+                  service: 'unknown-service',
+                },
+              },
+              attributes: {},
+              variables: {},
+            },
+          },
+        },
+        rules: [unknownApiServiceRule],
+      }),
+    )
+
+    expect(problems).toHaveLength(1)
+    expect(problems[0].code).toBe('unknown api service')
+    expect(problems[0].path).toEqual([
+      'components',
+      'apiComponent',
+      'apis',
+      'my-other-api',
+      'service',
+    ])
+    expect(problems[0].details).toEqual({
+      apiName: 'my-other-api',
+      serviceName: 'unknown-service',
+    })
+  })
+})
+
+describe('fix unknownApiServiceRule', () => {
+  test('should remove references to unknown services', () => {
+    const project: ProjectFiles = {
+      formulas: {},
+      services: {
+        'used-service': {
+          name: 'used-service',
+          type: 'supabase',
+          meta: {},
+        },
+      },
+      components: {
+        apiComponent: {
+          name: 'test',
+          nodes: {},
+          formulas: {},
+          apis: {
+            'my-api': {
+              name: 'my-api',
+              type: 'http',
+              version: 2,
+              autoFetch: valueFormula(true),
+              inputs: {},
+              service: 'used-service',
+            },
+            'my-other-api': {
+              name: 'my-api',
+              type: 'http',
+              version: 2,
+              autoFetch: valueFormula(true),
+              inputs: {},
+              service: 'unknown-service',
+            },
+          },
+          onLoad: {
+            trigger: 'onLoad',
+            actions: [],
+          },
+          attributes: {},
+          variables: {},
+        },
+      },
+    }
+    const fixedProject = fixProject({
+      files: project,
+      rule: unknownApiServiceRule,
+      fixType: 'delete-api-service-reference',
+    })
+    expect(
+      (
+        fixedProject.components['apiComponent']?.apis[
+          'my-other-api'
+        ] as ApiRequest
+      ).service,
+    ).toBeUndefined()
+    expect(fixedProject.components['apiComponent']?.apis)
+      .toMatchInlineSnapshot(`
+      {
+        "my-api": {
+          "autoFetch": {
+            "type": "value",
+            "value": true,
+          },
+          "inputs": {},
+          "name": "my-api",
+          "service": "used-service",
+          "type": "http",
+          "version": 2,
+        },
+        "my-other-api": {
+          "autoFetch": {
+            "type": "value",
+            "value": true,
+          },
+          "inputs": {},
+          "name": "my-api",
+          "type": "http",
+          "version": 2,
+        },
+      }
+    `)
+  })
+})

--- a/packages/search/src/rules/apis/unknownApiServiceRule.ts
+++ b/packages/search/src/rules/apis/unknownApiServiceRule.ts
@@ -1,0 +1,33 @@
+import { isLegacyApi } from '@nordcraft/core/dist/api/api'
+import { isDefined } from '@nordcraft/core/dist/utils/util'
+import type { Rule } from '../../types'
+import { removeFromPathFix } from '../../util/removeUnused.fix'
+
+export const unknownApiServiceRule: Rule<{
+  apiName: string
+  serviceName: string
+}> = {
+  code: 'unknown api service',
+  level: 'warning',
+  category: 'Unknown Reference',
+  visit: (report, args) => {
+    if (
+      args.nodeType !== 'component-api' ||
+      isLegacyApi(args.value) ||
+      !isDefined(args.value.service) ||
+      isDefined(args.files.services?.[args.value.service])
+    ) {
+      return
+    }
+    report(
+      [...args.path, 'service'],
+      { apiName: args.value.name, serviceName: args.value.service },
+      ['delete-api-service-reference'],
+    )
+  },
+  fixes: {
+    'delete-api-service-reference': removeFromPathFix,
+  },
+}
+
+export type UnknownApiServiceRuleFix = 'delete-api-service-reference'

--- a/packages/search/src/types.d.ts
+++ b/packages/search/src/types.d.ts
@@ -26,6 +26,7 @@ import type { LegacyActionRuleFix } from './rules/actions/legacyActionRule'
 import type { NoReferenceProjectActionRuleFix } from './rules/actions/noReferenceProjectActionRule'
 import type { NoReferenceApiRuleFix } from './rules/apis/noReferenceApiRule'
 import type { NoReferenceApiServiceRuleFix } from './rules/apis/noReferenceApiServiceRule'
+import type { UnknownApiServiceRuleFix } from './rules/apis/unknownApiServiceRule'
 import type { NoReferenceAttributeRuleFix } from './rules/attributes/noReferenceAttributeRule'
 import type { UnknownComponentAttributeRuleFix } from './rules/attributes/unknownComponentAttributeRule'
 import type { NoReferenceComponentRuleFix } from './rules/components/noReferenceComponentRule'
@@ -78,6 +79,7 @@ type Code =
   | 'image without dimension'
   | 'unknown api input'
   | 'unknown api'
+  | 'unknown api service'
   | 'unknown attribute'
   | 'unknown classname'
   | 'unknown component attribute'
@@ -366,6 +368,7 @@ type FixType =
   | NoStaticNodeConditionRuleFix
   | NoPostNavigateActionRuleFix
   | UnknownComponentAttributeRuleFix
+  | UnknownApiServiceRuleFix
 
 export interface Rule<T = unknown, V = NodeType> {
   category: Category


### PR DESCRIPTION
While it's not an issue to have a broken reference to an API service, it's probably a mistake and could cover a real issue if the service was accidentally deleted.