### PR TITLE
Add indexing to meta tags to allow ordering

### DIFF
--- a/packages/core/src/component/component.types.ts
+++ b/packages/core/src/component/component.types.ts
@@ -150,6 +150,7 @@ export interface MetaEntry {
   tag: HeadTagTypes
   attrs: Record<string, Formula>
   content: Formula
+  index?: number
 }
 
 export interface StaticPathSegment {

--- a/packages/ssr/src/rendering/head.ts
+++ b/packages/ssr/src/rendering/head.ts
@@ -273,7 +273,11 @@ export const getHeadItems = ({
   }
   // Handle custom meta tags last to allow overriding defaults
   if (pageInfo?.meta) {
-    Object.entries(pageInfo.meta).forEach(([id, metaEntry]) => {
+    easySort(
+      Object.entries(pageInfo.meta),
+      // Sort by index if it exists
+      ([_, meta]) => meta.index ?? Infinity,
+    ).forEach(([id, metaEntry]) => {
       if (Object.values(HeadTagTypes).includes(metaEntry.tag)) {
         // If the tag has a name or property attribute, we use that as the key
         // to avoid duplicates and to ensure sorting of tags later


### PR DESCRIPTION
For some meta tags, like scripts, the ordering matters. This adds an optional `index` field to the meta tag definition that allows specifying the order in which they should appear in the head. In the editor, we will support reordering these tags and provide the tags with indexes when they are modified.