### PR TITLE
Support nullable actions in test data removal

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nordcraft",
   "type": "module",
   "license": "Apache-2.0",
-  "version": "1.0.51",
+  "version": "1.0.52",
   "homepage": "https://github.com/nordcraftengine/nordcraft",
   "private": "false",
   "workspaces": [

--- a/packages/core/src/component/component.types.ts
+++ b/packages/core/src/component/component.types.ts
@@ -106,7 +106,7 @@ export interface ElementNodeModel {
   variants?: StyleVariant[]
   animations?: Record<string, Record<string, AnimationKeyframe>>
   children: string[]
-  events: Record<string, EventModel | null>
+  events: Partial<Record<string, EventModel | null>>
   classes: Record<string, { formula?: Formula }>
   'style-variables'?: Array<StyleVariable>
   customProperties?: Record<CustomPropertyName, CustomProperty>

--- a/packages/ssr/src/rendering/testData.ts
+++ b/packages/ssr/src/rendering/testData.ts
@@ -7,6 +7,7 @@ import type {
 } from '@nordcraft/core/dist/component/component.types'
 import { isFormula, type Formula } from '@nordcraft/core/dist/formula/formula'
 import { mapObject, omitKeys } from '@nordcraft/core/dist/utils/collections'
+import { isDefined } from '@nordcraft/core/dist/utils/util'
 
 export const removeTestData = (component: Component): Component => ({
   ...component,
@@ -109,6 +110,9 @@ export const removeTestData = (component: Component): Component => ({
 })
 
 const removeActionTestData = (action: ActionModel): ActionModel => {
+  if (!isDefined(action)) {
+    return action
+  }
   switch (action.type) {
     case 'SetVariable':
       return {
@@ -241,6 +245,9 @@ const removeActionTestData = (action: ActionModel): ActionModel => {
 }
 
 const removeActionArgumentTestData = (action: CustomActionArgument) => {
+  if (!isDefined(action)) {
+    return action
+  }
   return {
     ...omitKeys(action, ['description', 'type']),
     formula: action.formula


### PR DESCRIPTION
To avoid unrecoverable errors when action is null or undefined, we should support them gracefully.