### PR TITLE
Update concatenate docs to include objects

### DIFF
--- a/packages/lib/formulas/concatenate/formula.json
+++ b/packages/lib/formulas/concatenate/formula.json
@@ -10,15 +10,15 @@
         "value": ""
       },
       "type": {
-        "type": "Array \\| String"
+        "type": "Array \\| String \\| Object"
       }
     }
   ],
   "variableArguments": true,
   "output": {
     "type": {
-      "type": "Array \\| String"
+      "type": "Array \\| String \\| Object"
     },
-    "description": "Returns a String or Array containing all the specified input values."
+    "description": "Returns a String, Array or Object containing all the specified input values."
   }
 }


### PR DESCRIPTION
Concatenate currently supports strings, arrays and objects, but the docs only stated strings and arrays. This could cause some confusion.