### PR TITLE
Support multiple header values in API proxy

### DIFF
--- a/packages/backend/src/routes/apiProxy.ts
+++ b/packages/backend/src/routes/apiProxy.ts
@@ -132,7 +132,7 @@ export const proxyRequestHandler = async (
       : ((response.body ?? new ReadableStream()) as ReadableStream)
 
     response.headers.entries().forEach(([name, value]) => {
-      c.header(name, value)
+      c.header(name, value, { append: true })
     })
     c.status(response.status as StatusCode)
     if (body) {

--- a/packages/backend/src/routes/font.ts
+++ b/packages/backend/src/routes/font.ts
@@ -38,7 +38,7 @@ fontRouter.get('/stylesheet/:stylesheet{.*}', async (c: Context<HonoEnv>) => {
     }
     const headers = filterFontResponseHeaders(response.headers)
     Array.from(headers.entries()).forEach(([name, value]) =>
-      c.header(name, value),
+      c.header(name, value, { append: true }),
     )
     return c.body(stylesheetContent)
   } catch {
@@ -56,7 +56,7 @@ fontRouter.get('/font/:font{.*}', async (c: Context<HonoEnv>) => {
     )) as any as Response
     const headers = filterFontResponseHeaders(response.headers)
     Array.from(headers.entries()).forEach(([name, value]) =>
-      c.header(name, value),
+      c.header(name, value, { append: true }),
     )
     if (response.ok && response.body) {
       return c.body(response.body, response.status as any)

--- a/packages/backend/src/routes/routeHandler.ts
+++ b/packages/backend/src/routes/routeHandler.ts
@@ -86,7 +86,7 @@ export const routeHandler: Handler<HonoEnv<HonoRoutes & HonoProject>> = async (
       ? undefined
       : ((response.body ?? new ReadableStream()) as ReadableStream)
     response.headers.entries().forEach(([name, value]) => {
-      c.header(name, value)
+      c.header(name, value, { append: true })
     })
     c.status(response.status as StatusCode)
     if (body) {


### PR DESCRIPTION
In case of non-unique headers, we should support multiple values for the same header name - for instance `Set-Cookie`.