### PR TITLE
Add invalid proxy+cookie setting rule

### DIFF
--- a/packages/search/src/rules/issues/apis/apiRules.index.ts
+++ b/packages/search/src/rules/issues/apis/apiRules.index.ts
@@ -1,5 +1,6 @@
 import { invalidApiParserModeRule } from './invalidApiParserModeRule'
 import { invalidApiProxyBodySettingRule } from './invalidApiProxyBodySettingRule'
+import { invalidApiProxyCookieSettingRule } from './invalidApiProxyCookieSettingRule'
 import { legacyApiRule } from './legacyApiRule'
 import { noReferenceApiRule } from './noReferenceApiRule'
 import { noReferenceApiServiceRule } from './noReferenceApiServiceRule'
@@ -8,11 +9,12 @@ import { unknownApiRule } from './unknownApiRule'
 import { unknownApiServiceRule } from './unknownApiServiceRule'
 
 export default [
+  // noReferenceApiInputRule,
   invalidApiParserModeRule,
   invalidApiProxyBodySettingRule,
+  invalidApiProxyCookieSettingRule,
   legacyApiRule,
   noReferenceApiRule,
-  // noReferenceApiInputRule,
   noReferenceApiServiceRule,
   unknownApiInputRule,
   unknownApiRule,

--- a/packages/search/src/rules/issues/apis/invalidApiProxyCookieSettingRule.test.ts
+++ b/packages/search/src/rules/issues/apis/invalidApiProxyCookieSettingRule.test.ts
@@ -1,6 +1,6 @@
 import { valueFormula } from '@nordcraft/core/dist/formula/formulaUtils'
 import { describe, expect, test } from 'bun:test'
-import { searchProject } from '../../searchProject'
+import { searchProject } from '../../../searchProject'
 import { invalidApiProxyCookieSettingRule } from './invalidApiProxyCookieSettingRule'
 
 describe('invalidApiProxyCookieSettingRule', () => {

--- a/packages/search/src/rules/issues/apis/invalidApiProxyCookieSettingRule.test.ts
+++ b/packages/search/src/rules/issues/apis/invalidApiProxyCookieSettingRule.test.ts
@@ -1,0 +1,132 @@
+import { valueFormula } from '@nordcraft/core/dist/formula/formulaUtils'
+import { describe, expect, test } from 'bun:test'
+import { searchProject } from '../../searchProject'
+import { invalidApiProxyCookieSettingRule } from './invalidApiProxyCookieSettingRule'
+
+describe('invalidApiProxyCookieSettingRule', () => {
+  test('should report invalid usage of GetHttpOnlyCookie when the API is not proxied', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          components: {
+            test: {
+              name: 'test',
+              nodes: {},
+              formulas: {},
+              apis: {
+                'my-api': {
+                  name: 'my-api',
+                  type: 'http',
+                  version: 2,
+                  autoFetch: valueFormula(true),
+                  inputs: {},
+                  headers: {
+                    Authorization: {
+                      formula: {
+                        type: 'function',
+                        name: '@toddle/concatenate',
+                        arguments: [
+                          { formula: { type: 'value', value: 'Bearer ' } },
+                          {
+                            formula: {
+                              type: 'function',
+                              name: '@toddle/getHttpOnlyCookie',
+                              arguments: [
+                                {
+                                  formula: {
+                                    type: 'value',
+                                    value: 'access_token',
+                                  },
+                                },
+                              ],
+                              display_name: 'Get Http-Only Cookie',
+                            },
+                          },
+                        ],
+                        display_name: 'Concatenate',
+                      },
+                    },
+                  },
+                  server: {
+                    proxy: {
+                      enabled: { formula: valueFormula(true) },
+                    },
+                  },
+                },
+              },
+              attributes: {},
+              variables: {},
+            },
+          },
+        },
+        rules: [invalidApiProxyCookieSettingRule],
+      }),
+    )
+
+    expect(problems).toHaveLength(1)
+    expect(problems[0].code).toBe('invalid api proxy body setting')
+    expect(problems[0].details).toEqual({ api: 'my-api' })
+  })
+
+  test('should not report valid usage of GetHttpOnlyCookie when API is proxied', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          components: {
+            test: {
+              name: 'test',
+              nodes: {},
+              formulas: {},
+              apis: {
+                'my-api': {
+                  name: 'my-api',
+                  type: 'http',
+                  version: 2,
+                  autoFetch: valueFormula(true),
+                  inputs: {},
+                  headers: {
+                    Authorization: {
+                      formula: {
+                        type: 'function',
+                        name: '@toddle/concatenate',
+                        arguments: [
+                          { formula: { type: 'value', value: 'Bearer ' } },
+                          {
+                            formula: {
+                              type: 'function',
+                              name: '@toddle/getHttpOnlyCookie',
+                              arguments: [
+                                {
+                                  formula: {
+                                    type: 'value',
+                                    value: 'access_token',
+                                  },
+                                },
+                              ],
+                              display_name: 'Get Http-Only Cookie',
+                            },
+                          },
+                        ],
+                        display_name: 'Concatenate',
+                      },
+                    },
+                  },
+                  server: {
+                    proxy: {
+                      enabled: { formula: valueFormula(false) },
+                    },
+                  },
+                },
+              },
+              attributes: {},
+              variables: {},
+            },
+          },
+        },
+        rules: [invalidApiProxyCookieSettingRule],
+      }),
+    )
+
+    expect(problems).toEqual([])
+  })
+})

--- a/packages/search/src/rules/issues/apis/invalidApiProxyCookieSettingRule.ts
+++ b/packages/search/src/rules/issues/apis/invalidApiProxyCookieSettingRule.ts
@@ -1,6 +1,6 @@
 import { isLegacyApi } from '@nordcraft/core/dist/api/api'
 import { get } from '@nordcraft/core/dist/utils/collections'
-import type { Rule } from '../../types'
+import type { Rule } from '../../../types'
 
 export const invalidApiProxyCookieSettingRule: Rule<{ api: string }> = {
   code: 'invalid api proxy body setting',

--- a/packages/search/src/rules/issues/apis/invalidApiProxyCookieSettingRule.ts
+++ b/packages/search/src/rules/issues/apis/invalidApiProxyCookieSettingRule.ts
@@ -1,0 +1,37 @@
+import { isLegacyApi } from '@nordcraft/core/dist/api/api'
+import { get } from '@nordcraft/core/dist/utils/collections'
+import type { Rule } from '../../types'
+
+export const invalidApiProxyCookieSettingRule: Rule<{ api: string }> = {
+  code: 'invalid api proxy body setting',
+  level: 'warning',
+  category: 'Quality',
+  visit: (report, { files, nodeType, value, path }) => {
+    if (
+      nodeType !== 'formula' ||
+      value.type !== 'function' ||
+      value.name !== '@toddle/getHttpOnlyCookie'
+    ) {
+      return
+    }
+    const [_components, componentName, apis, apiName] = path
+    if (
+      apis !== 'apis' ||
+      typeof componentName !== 'string' ||
+      typeof apiName !== 'string'
+    ) {
+      return
+    }
+    const api = get(files, ['components', componentName, 'apis', apiName])
+    if (
+      !api ||
+      isLegacyApi(api) ||
+      api.server?.proxy?.enabled?.formula.type !== 'value' ||
+      api.server.proxy.enabled.formula.value !== true
+    ) {
+      return
+    }
+    // Report an issue if the  is set to true while the API is not set to be proxied
+    report(path, { api: api.name })
+  },
+}


### PR DESCRIPTION
This rule flags usage of the `Get Http-Only Cookie` formula in APIs that are not proxied. This formula won't work in non-proxied APIs since it's a Nordcraft only feature/pattern.