### PR TITLE
Cleanup types for style variants

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,9 +3,6 @@
   "license": "Apache-2.0",
   "type": "module",
   "homepage": "https://github.com/nordcraftengine/nordcraft",
-  "devDependencies": {
-    "@types/react": "19.1.8"
-  },
   "scripts": {
     "build": "tsc",
     "npm-publish": "bun run build && bun publish --access public",

--- a/packages/core/src/component/component.types.ts
+++ b/packages/core/src/component/component.types.ts
@@ -1,6 +1,7 @@
 import type { ApiStatus, ComponentAPI, LegacyApiStatus } from '../api/apiTypes'
 import type { Formula } from '../formula/formula'
 import type { StyleTokenCategory } from '../styling/theme'
+import type { StyleVariant } from '../styling/variantSelector'
 import type { NordcraftMetadata, RequireFields } from '../types'
 
 interface ListItem {
@@ -44,35 +45,15 @@ export interface AnimationKeyframe {
   easing?: never
 }
 
-export interface StyleVariant {
-  id?: string
-  className?: string
-  hover?: boolean
-  focus?: boolean
-  focusWithin?: boolean
-  active?: boolean
-  disabled?: boolean
-  firstChild?: boolean
-  lastChild?: boolean
-  evenChild?: boolean
-  empty?: boolean
-  mediaQuery?: MediaQuery
-  breakpoint: 'small' | 'medium' | 'large'
-  startingStyle?: boolean
-  pseudoElement?: string
-  style: NodeStyleModel
-  customProperties?: Record<CustomPropertyName, CustomProperty>
-}
-
 export type NodeStyleModel = Record<string, string>
 
 export interface TextNodeModel {
-  id?: string
+  id?: string | null
   type: 'text'
-  condition?: Formula
-  repeat?: Formula
-  slot?: string
-  repeatKey?: Formula
+  condition?: Formula | null
+  repeat?: Formula | null
+  slot?: string | null
+  repeatKey?: Formula | null
   value: Formula
   children?: undefined
 }
@@ -97,13 +78,13 @@ export interface ElementNodeModel {
   id?: string
   type: 'element'
   slot?: string
-  condition?: Formula
-  repeat?: Formula
-  repeatKey?: Formula
+  condition?: Formula | null
+  repeat?: Formula | null
+  repeatKey?: Formula | null
   tag: string
   attrs: Partial<Record<string, Formula>>
   style: NodeStyleModel
-  variants?: StyleVariant[]
+  variants?: StyleVariant[] | null
   animations?: Record<string, Record<string, AnimationKeyframe>>
   children: string[]
   events: Partial<Record<string, EventModel | null>>
@@ -119,11 +100,11 @@ export interface ComponentNodeModel {
   path?: string
   name: string
   package?: string
-  condition?: Formula
-  repeat?: Formula
-  repeatKey?: Formula
+  condition?: Formula | null
+  repeat?: Formula | null
+  repeatKey?: Formula | null
   style?: NodeStyleModel
-  variants?: StyleVariant[]
+  variants?: StyleVariant[] | null
   animations?: Record<string, Record<string, AnimationKeyframe>>
   attrs: Record<string, Formula>
   children: string[]
@@ -135,9 +116,9 @@ export interface SlotNodeModel {
   type: 'slot'
   slot?: string
   name?: string
-  condition?: Formula
-  repeat?: undefined
-  repeatKey?: undefined
+  condition?: Formula | null
+  repeat?: undefined | null
+  repeatKey?: undefined | null
   children: string[]
 }
 export type NodeModel =
@@ -149,8 +130,8 @@ export type NodeModel =
 export interface MetaEntry {
   tag: HeadTagTypes
   attrs: Record<string, Formula>
-  content: Formula
-  index?: number
+  content?: Formula | null
+  index?: number | null
 }
 
 export interface StaticPathSegment {
@@ -182,26 +163,26 @@ export interface Component {
    * @default undefined (version 1)
    * @deprecated - we are no longer using version 2 components, but we are keeping this field for backwards compatibility
    */
-  version?: 2
+  version?: 2 | null
   // @deprecated - use route->path instead
-  page?: string // page url /projects/:id - only for pages
+  page?: string | null // page url /projects/:id - only for pages
   route?: PageRoute | null
   attributes: Record<string, ComponentAttribute>
   variables: Record<string, ComponentVariable>
-  formulas?: Record<string, ComponentFormula>
+  formulas?: Record<string, ComponentFormula> | null
   contexts?: Record<
     // `componentName` or `packageName/componentName` if the context comes from a different package than the component itself
     string,
     ComponentContext
-  >
-  workflows?: Record<string, ComponentWorkflow>
+  > | null
+  workflows?: Record<string, ComponentWorkflow> | null
   apis: Record<string, ComponentAPI>
   nodes: Record<string, NodeModel>
-  events?: ComponentEvent[]
-  onLoad?: EventModel
-  onAttributeChange?: EventModel
+  events?: ComponentEvent[] | null
+  onLoad?: EventModel | null
+  onAttributeChange?: EventModel | null
   // exported indicates that a component is exported in a package
-  exported?: boolean
+  exported?: boolean | null
 }
 
 export interface ComponentFormula extends NordcraftMetadata {

--- a/packages/core/src/styling/style.css.ts
+++ b/packages/core/src/styling/style.css.ts
@@ -1,15 +1,15 @@
 // cSpell:ignore thinn, ABCDEFGHIJKLMNOPQRSTYVWXYZ
-import type { Component } from '../component/component.types'
+import type {
+  Component,
+  ComponentNodeModel,
+  ElementNodeModel,
+  NodeStyleModel,
+} from '../component/component.types'
 import { omitKeys } from '../utils/collections'
 import { isDefined } from '../utils/util'
 import { getClassName, toValidClassName } from './className'
 import type { OldTheme, Theme, ThemeOptions } from './theme'
 import { getThemeCss } from './theme'
-import type {
-  ComponentNodeModel,
-  ElementNodeModel,
-  StyleDeclarationBlock,
-} from './variantSelector'
 import { variantSelector } from './variantSelector'
 
 const LEGACY_BREAKPOINTS = {
@@ -108,7 +108,7 @@ export const createStylesheet = (
     ),
     options,
   )
-  const styleToCss = (style: StyleDeclarationBlock) => {
+  const styleToCss = (style: NodeStyleModel) => {
     return Object.entries(style)
       .map(([property, value]) => {
         if (!isDefined(value)) {
@@ -136,10 +136,10 @@ export const createStylesheet = (
         'breakpoints',
         'shadows',
       ])
-      const styleVariants = node.variants ?? node.style?.variants
+      const styleVariants = node.variants
       const renderVariant = (
         selector: string,
-        style: StyleDeclarationBlock,
+        style: NodeStyleModel,
         options?: { startingStyle?: boolean },
       ) => {
         const scrollbarStyles = Object.entries(style).filter(

--- a/packages/core/src/styling/variantSelector.ts
+++ b/packages/core/src/styling/variantSelector.ts
@@ -1,12 +1,8 @@
-import type { CSSProperties } from 'react'
 import type {
-  AnimationKeyframe,
   CustomProperty,
   CustomPropertyName,
-  EventModel,
-  StyleVariable,
+  NodeStyleModel,
 } from '../component/component.types'
-import type { Formula } from '../formula/formula'
 
 export type Shadow = {
   x: number
@@ -27,11 +23,6 @@ export type Filter =
       percent: number
     }
 
-export interface StyleDeclarationBlock extends CSSProperties {
-  filters?: Filter[]
-  shadows?: Shadow[]
-}
-
 type MediaQuery = {
   'min-width'?: string
   'max-width'?: string
@@ -40,8 +31,6 @@ type MediaQuery = {
 }
 
 export interface StyleVariant {
-  autofill?: boolean
-  'nth-child(even)'?: boolean
   'even-child'?: boolean
   'first-child'?: boolean
   'first-of-type'?: boolean
@@ -49,12 +38,15 @@ export interface StyleVariant {
   'focus-within'?: boolean
   'last-child'?: boolean
   'last-of-type'?: boolean
+  'nth-child(even)'?: boolean
   'popover-open'?: boolean
   active?: boolean
+  autofill?: boolean
   breakpoint: 'small' | 'medium' | 'large'
   checked?: boolean
   class?: string
   className?: string
+  customProperties?: Record<CustomPropertyName, CustomProperty>
   disabled?: boolean
   empty?: boolean
   evenChild?: boolean
@@ -69,85 +61,8 @@ export interface StyleVariant {
   mediaQuery?: MediaQuery
   pseudoElement?: string
   startingStyle?: boolean
-  style: StyleDeclarationBlock
-  visited?: boolean
-  customProperties?: Record<CustomPropertyName, CustomProperty>
-}
-
-export interface NodeStyleModel extends StyleDeclarationBlock {
-  variants?: StyleVariant[]
-  breakpoints?: {
-    small?: NodeStyleModel
-    medium?: NodeStyleModel
-    large?: NodeStyleModel
-  }
-  mediaQuery?: MediaQuery
-}
-
-export type NodeClass = {
-  name: string
-  formula?: Formula
-}
-
-export type NodeModel =
-  | ElementNodeModel
-  | TextNodeModel
-  | ComponentNodeModel
-  | SlotNodeModel
-
-export type ElementNodeModel = {
-  id: string
-  type: 'element'
-  condition?: Formula
-  repeat?: Formula
-  repeatKey?: Formula
-  tag: string
-  classList: NodeClass[]
-  attrs: Record<string, Formula>
   style: NodeStyleModel
-  variants?: StyleVariant[]
-  animations?: Record<string, Record<string, AnimationKeyframe>>
-  children: NodeModel[]
-  events: EventModel[]
-  'style-variables'?: Array<StyleVariable>
-  customProperties?: Record<CustomPropertyName, CustomProperty>
-}
-
-export type ComponentNodeModel = {
-  id: string
-  type: 'component'
-  path?: string
-  name: string
-  condition?: Formula
-  repeat?: Formula
-  repeatKey?: Formula
-  style?: NodeStyleModel
-  variants?: StyleVariant[]
-  animations?: Record<string, Record<string, AnimationKeyframe>>
-  attrs: Record<string, Formula>
-  children: NodeModel[]
-  events: EventModel[]
-  'style-variables'?: Array<StyleVariable>
-  customProperties?: Record<CustomPropertyName, CustomProperty>
-}
-
-export type TextNodeModel = {
-  id: string
-  type: 'text'
-  condition?: Formula
-  repeat?: Formula
-  repeatKey?: Formula
-  value: Formula
-  children?: undefined
-}
-
-export type SlotNodeModel = {
-  id: string
-  type: 'slot'
-  condition?: Formula
-  repeat?: undefined
-  repeatKey?: Formula
-  children: NodeModel[]
+  visited?: boolean
 }
 
 export const variantSelector = (variant: StyleVariant) =>

--- a/packages/core/src/utils/getNodeSelector.ts
+++ b/packages/core/src/utils/getNodeSelector.ts
@@ -1,5 +1,4 @@
-import type { StyleVariant } from '../component/component.types'
-import { variantSelector } from '../styling/variantSelector'
+import { variantSelector, type StyleVariant } from '../styling/variantSelector'
 
 type NodeSelectorOptions =
   | {

--- a/packages/runtime/src/editor-preview.main.ts
+++ b/packages/runtime/src/editor-preview.main.ts
@@ -9,7 +9,6 @@ import {
   type Component,
   type ComponentData,
   type MetaEntry,
-  type StyleVariant,
 } from '@nordcraft/core/dist/component/component.types'
 import { isPageComponent } from '@nordcraft/core/dist/component/isPageComponent'
 import type {
@@ -27,6 +26,7 @@ import { valueFormula } from '@nordcraft/core/dist/formula/formulaUtils'
 import { getClassName } from '@nordcraft/core/dist/styling/className'
 import type { OldTheme, Theme } from '@nordcraft/core/dist/styling/theme'
 import { getThemeCss, renderTheme } from '@nordcraft/core/dist/styling/theme'
+import type { StyleVariant } from '@nordcraft/core/dist/styling/variantSelector'
 import type {
   ActionHandler,
   ActionHandlerV2,

--- a/packages/runtime/src/styles/style.ts
+++ b/packages/runtime/src/styles/style.ts
@@ -84,7 +84,7 @@ ${
         .map((variant) => {
           const selector = `.${classHash}${variantSelector(variant)}`
           const renderedVariant = renderVariant(selector, variant.style, {
-            startingStyle: variant.startingStyle,
+            startingStyle: variant.startingStyle ?? false,
           })
           return variant.mediaQuery
             ? `

--- a/packages/runtime/src/utils/omitStyle.ts
+++ b/packages/runtime/src/utils/omitStyle.ts
@@ -1,7 +1,5 @@
-import type {
-  Component,
-  StyleVariant,
-} from '@nordcraft/core/dist/component/component.types'
+import type { Component } from '@nordcraft/core/dist/component/component.types'
+import type { StyleVariant } from '@nordcraft/core/dist/styling/variantSelector'
 
 export function omitSubnodeStyleForComponent<T extends Component | undefined>(
   component: T,

--- a/packages/runtime/src/utils/subscribeCustomProperty.ts
+++ b/packages/runtime/src/utils/subscribeCustomProperty.ts
@@ -1,7 +1,7 @@
-import type { StyleVariant } from '@nordcraft/core/dist/component/component.types'
 import type { Signal } from '../signal/signal'
 
 import { CUSTOM_PROPERTIES_STYLESHEET_ID } from '@nordcraft/core/dist/styling/theme.const'
+import type { StyleVariant } from '@nordcraft/core/dist/styling/variantSelector'
 import type { Runtime } from '@nordcraft/core/dist/types'
 import { CustomPropertyStyleSheet } from '../styles/CustomPropertyStyleSheet'
 


### PR DESCRIPTION
We had 2 declarations/versions of the types for style variants. This cleans it up to use only one as well as simplify the types for style variant styles.
This cleanup also means we no longer need to rely on types from `react`.