### PR TITLE
Use args instead of construct/destruct for formulas to reduce memory usage

### DIFF
--- a/packages/core/src/formula/andFormula.ts
+++ b/packages/core/src/formula/andFormula.ts
@@ -1,11 +1,25 @@
+import type { ComponentData } from '../component/component.types'
 import { toBoolean } from '../utils/util'
 import { applyFormula, type AndOperation, type FormulaContext } from './formula'
 
-export const applyAndFormula = (formula: AndOperation, ctx: FormulaContext) => {
+export const applyAndFormula = (
+  formula: AndOperation,
+  ctx: FormulaContext,
+  data: ComponentData,
+  args: any,
+  packageName: string | null | undefined,
+  jsonPath: Array<string | number> | undefined,
+) => {
   for (let i = 0; i < (formula.arguments ?? []).length; i++) {
     const arg = (formula.arguments ?? [])[i]
     if (
-      !toBoolean(applyFormula(arg?.formula, ctx, ['arguments', i, 'formula']))
+      !toBoolean(
+        applyFormula(arg?.formula, ctx, data, args, packageName, jsonPath, [
+          'arguments',
+          i,
+          'formula',
+        ]),
+      )
     ) {
       return false
     }
@@ -16,6 +30,10 @@ export const applyAndFormula = (formula: AndOperation, ctx: FormulaContext) => {
 export const applyEvaluateAllAndFormula = (
   formula: AndOperation,
   ctx: FormulaContext,
+  data: ComponentData,
+  args: any,
+  packageName: string | null | undefined,
+  jsonPath: Array<string | number> | undefined,
 ) => {
   let andResult = true
   if (!formula.arguments || formula.arguments.length === 0) {
@@ -24,7 +42,13 @@ export const applyEvaluateAllAndFormula = (
   for (let i = 0; i < (formula.arguments ?? []).length; i++) {
     const arg = (formula.arguments ?? [])[i]
     if (
-      !toBoolean(applyFormula(arg?.formula, ctx, ['arguments', i, 'formula']))
+      !toBoolean(
+        applyFormula(arg?.formula, ctx, data, args, packageName, jsonPath, [
+          'arguments',
+          i,
+          'formula',
+        ]),
+      )
     ) {
       andResult = false
     }

--- a/packages/core/src/formula/applyFormula.ts
+++ b/packages/core/src/formula/applyFormula.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+import type { ComponentData } from '../component/component.types'
 import { measure } from '../utils/measure'
 import {
   applyFormula,
@@ -9,6 +10,11 @@ import {
 export const applyApplyFormula = (
   formula: ApplyOperation,
   ctx: FormulaContext,
+  data: ComponentData,
+  currentArgs: any,
+  currentPackage: string | null | undefined,
+  jsonPath: Array<string | number> | undefined,
+  // eslint-disable-next-line max-params
 ) => {
   const componentFormula = ctx.component?.formulas?.[formula.name]
   if (!componentFormula) {
@@ -20,53 +26,67 @@ export const applyApplyFormula = (
     }
     return null
   }
-  const stopMeasure = measure(`Formula: ${componentFormula.name}`, {
-    formula,
-    component: ctx.component?.name,
-  })
-  const Input = Object.fromEntries(
-    (formula.arguments ?? []).map((arg, i) =>
-      arg.isFunction
-        ? [
-            arg.name,
-            (Args: any) =>
-              applyFormula(
-                arg.formula,
-                {
-                  ...ctx,
-                  data: {
-                    ...ctx.data,
-                    Args: ctx.data.Args
-                      ? { ...Args, '@toddle.parent': ctx.data.Args }
-                      : Args,
-                  },
-                },
-                ['arguments', i],
-              ),
-          ]
-        : [arg.name, applyFormula(arg.formula, ctx, ['arguments', i])],
-    ),
-  )
-  const data = {
-    ...ctx.data,
-    Args: ctx.data.Args ? { ...Input, '@toddle.parent': ctx.data.Args } : Input,
+  const stopMeasure = measure(() => [
+    `Formula: ${componentFormula.name}`,
+    {
+      formula,
+      component: ctx.component?.name,
+    },
+  ])
+
+  const Input: Record<string, any> = {}
+  const formulaArguments = formula.arguments ?? []
+  for (let i = 0; i < formulaArguments.length; i++) {
+    const arg = formulaArguments[i]
+    if (!arg) {
+      continue
+    }
+    const name = arg.name ?? `${i}`
+    Input[name] = arg.isFunction
+      ? (nestedArgs: any) =>
+          applyFormula(
+            arg.formula,
+            ctx,
+            data,
+            currentArgs
+              ? { ...nestedArgs, '@toddle.parent': currentArgs }
+              : nestedArgs,
+            currentPackage,
+            jsonPath,
+            ['arguments', i],
+          )
+      : applyFormula(
+          arg.formula,
+          ctx,
+          data,
+          currentArgs,
+          currentPackage,
+          jsonPath,
+          ['arguments', i],
+        )
   }
+
+  const boundArgs = currentArgs
+    ? { ...Input, '@toddle.parent': currentArgs }
+    : Input
+
   const cache = ctx.formulaCache?.[formula.name]?.get(data)
 
   if (cache?.hit) {
-    stopMeasure({ cache: 'hit' })
+    stopMeasure?.({ cache: 'hit' })
     return cache.data
   } else {
     const result = applyFormula(
       componentFormula.formula,
-      {
-        ...ctx,
-        data,
-      },
+      ctx,
+      data,
+      boundArgs,
+      currentPackage,
+      jsonPath,
       ['formula'],
     )
     ctx.formulaCache?.[formula.name]?.set(data, result)
-    stopMeasure({ cache: 'miss' })
+    stopMeasure?.({ cache: 'miss' })
     return result
   }
 }

--- a/packages/core/src/formula/arrayFormula.ts
+++ b/packages/core/src/formula/arrayFormula.ts
@@ -1,3 +1,4 @@
+import type { ComponentData } from '../component/component.types'
 import {
   applyFormula,
   type ArrayOperation,
@@ -7,8 +8,16 @@ import {
 export const applyArrayFormula = (
   formula: ArrayOperation,
   ctx: FormulaContext,
+  data: ComponentData,
+  args: any,
+  packageName: string | null | undefined,
+  jsonPath: Array<string | number> | undefined,
 ) => {
   return (formula.arguments ?? []).map((entry, i) =>
-    applyFormula(entry.formula, ctx, ['arguments', i, 'formula']),
+    applyFormula(entry.formula, ctx, data, args, packageName, jsonPath, [
+      'arguments',
+      i,
+      'formula',
+    ]),
   )
 }

--- a/packages/core/src/formula/formula.ts
+++ b/packages/core/src/formula/formula.ts
@@ -207,11 +207,33 @@ export const isToddleFormula = <Handler>(
   Object.hasOwn(formula, 'formula') &&
   isDefined((formula as ToddleFormula).formula)
 
+// Allowing max-params for performance reasons as this function is called 1000s of times, and alternative is destructuring which adds noticeable garbage collection overhead
+// eslint-disable-next-line max-params
 export function applyFormula(
   formula: Formula | string | number | undefined | null | boolean,
   ctx: FormulaContext,
+  dataOrExtendedPath?: ComponentData | Array<string | number> | undefined,
+  args?: any,
+  packageName?: string | null,
+  jsonPath?: Array<string | number> | undefined,
   extendedPath?: Array<string | number> | undefined,
 ): any {
+  let data: ComponentData
+  let actualExtendedPath: Array<string | number> | undefined = extendedPath
+
+  if (Array.isArray(dataOrExtendedPath)) {
+    data = ctx.data ?? ({ Attributes: {}, Variables: {} } as ComponentData)
+    actualExtendedPath = dataOrExtendedPath
+  } else {
+    data =
+      dataOrExtendedPath ??
+      ctx.data ??
+      ({ Attributes: {}, Variables: {} } as ComponentData)
+  }
+
+  const currentArgs = args !== undefined ? args : data?.Args
+  const currentPackage = packageName !== undefined ? packageName : ctx.package
+
   // Short-circuit when not reporting to avoid unnecessary overhead of creating new objects and function
   if (!ctx.reportFormulaEvaluation) {
     if (!isFormula(formula)) {
@@ -222,23 +244,79 @@ export function applyFormula(
         case 'value':
           return formula.value
         case 'path':
-          return applyPathFormula(formula, ctx.data)
+          return applyPathFormula(formula, data, currentArgs)
         case 'switch':
-          return applySwitchFormula(formula, ctx)
+          return applySwitchFormula(
+            formula,
+            ctx,
+            data,
+            currentArgs,
+            currentPackage,
+            jsonPath,
+          )
         case 'or':
-          return applyOrFormula(formula, ctx)
+          return applyOrFormula(
+            formula,
+            ctx,
+            data,
+            currentArgs,
+            currentPackage,
+            jsonPath,
+          )
         case 'and':
-          return applyAndFormula(formula, ctx)
+          return applyAndFormula(
+            formula,
+            ctx,
+            data,
+            currentArgs,
+            currentPackage,
+            jsonPath,
+          )
         case 'object':
-          return applyObjectFormula(formula, ctx)
+          return applyObjectFormula(
+            formula,
+            ctx,
+            data,
+            currentArgs,
+            currentPackage,
+            jsonPath,
+          )
         case 'record':
-          return applyRecordFormula(formula, ctx)
+          return applyRecordFormula(
+            formula,
+            ctx,
+            data,
+            currentArgs,
+            currentPackage,
+            jsonPath,
+          )
         case 'array':
-          return applyArrayFormula(formula, ctx)
+          return applyArrayFormula(
+            formula,
+            ctx,
+            data,
+            currentArgs,
+            currentPackage,
+            jsonPath,
+          )
         case 'function':
-          return applyFunctionFormula(formula, ctx)
+          return applyFunctionFormula(
+            formula,
+            ctx,
+            data,
+            currentArgs,
+            currentPackage,
+            jsonPath,
+          )
         case 'apply':
-          return applyApplyFormula(formula, ctx)
+          return applyApplyFormula(
+            formula,
+            ctx,
+            data,
+            currentArgs,
+            currentPackage,
+            jsonPath,
+          )
         default:
           if (ctx.env?.logErrors) {
             console.error('Could not recognize formula', formula)
@@ -254,9 +332,13 @@ export function applyFormula(
     return undefined
   }
 
-  const jsonPath = [...(ctx.jsonPath ?? []), ...(extendedPath ?? [])]
-  const _ctx = { ...ctx, jsonPath }
-  const report = (value: any, p: Array<string | number> = jsonPath) => {
+  const basePath = jsonPath !== undefined ? jsonPath : (ctx.jsonPath ?? [])
+  const currentPath = actualExtendedPath
+    ? [...basePath, ...actualExtendedPath]
+    : basePath
+
+  const _ctx = { ...ctx, jsonPath: currentPath, package: currentPackage }
+  const report = (value: any, p: Array<string | number> = currentPath) => {
     ctx.reportFormulaEvaluation?.(p, value, _ctx)
     return value
   }
@@ -270,50 +352,143 @@ export function applyFormula(
         return report(formula.value)
       }
       case 'path': {
-        return report(applyPathFormula(formula, _ctx.data))
+        return report(applyPathFormula(formula, data, currentArgs))
       }
       case 'switch': {
         if (
           _ctx.reportFormulaEvaluation &&
           _ctx.jsonPath.length < MAX_REPORT_DEPTH
         ) {
-          return report(applyEvaluateAllSwitchFormula(formula, _ctx))
+          return report(
+            applyEvaluateAllSwitchFormula(
+              formula,
+              ctx,
+              data,
+              currentArgs,
+              currentPackage,
+              currentPath,
+            ),
+          )
         }
-        return applySwitchFormula(formula, _ctx)
+        return applySwitchFormula(
+          formula,
+          ctx,
+          data,
+          currentArgs,
+          currentPackage,
+          currentPath,
+        )
       }
       case 'or': {
         if (
           _ctx.reportFormulaEvaluation &&
           _ctx.jsonPath.length < MAX_REPORT_DEPTH
         ) {
-          return report(applyEvaluateAllOrFormula(formula, _ctx))
+          return report(
+            applyEvaluateAllOrFormula(
+              formula,
+              ctx,
+              data,
+              currentArgs,
+              currentPackage,
+              currentPath,
+            ),
+          )
         }
-        return applyOrFormula(formula, _ctx)
+        return applyOrFormula(
+          formula,
+          ctx,
+          data,
+          currentArgs,
+          currentPackage,
+          currentPath,
+        )
       }
       case 'and': {
         if (
           _ctx.reportFormulaEvaluation &&
           _ctx.jsonPath.length < MAX_REPORT_DEPTH
         ) {
-          return report(applyEvaluateAllAndFormula(formula, _ctx))
+          return report(
+            applyEvaluateAllAndFormula(
+              formula,
+              ctx,
+              data,
+              currentArgs,
+              currentPackage,
+              currentPath,
+            ),
+          )
         }
-        return applyAndFormula(formula, _ctx)
+        return applyAndFormula(
+          formula,
+          ctx,
+          data,
+          currentArgs,
+          currentPackage,
+          currentPath,
+        )
       }
       case 'object': {
-        return report(applyObjectFormula(formula, _ctx))
+        return report(
+          applyObjectFormula(
+            formula,
+            ctx,
+            data,
+            currentArgs,
+            currentPackage,
+            currentPath,
+          ),
+        )
       }
       case 'record': {
         // object used to be called record, there are still examples in the wild.
-        return report(applyRecordFormula(formula, _ctx))
+        return report(
+          applyRecordFormula(
+            formula,
+            ctx,
+            data,
+            currentArgs,
+            currentPackage,
+            currentPath,
+          ),
+        )
       }
       case 'array': {
-        return report(applyArrayFormula(formula, _ctx))
+        return report(
+          applyArrayFormula(
+            formula,
+            ctx,
+            data,
+            currentArgs,
+            currentPackage,
+            currentPath,
+          ),
+        )
       }
       case 'function': {
-        return report(applyFunctionFormula(formula, _ctx))
+        return report(
+          applyFunctionFormula(
+            formula,
+            ctx,
+            data,
+            currentArgs,
+            currentPackage,
+            currentPath,
+          ),
+        )
       }
       case 'apply': {
-        return report(applyApplyFormula(formula, _ctx))
+        return report(
+          applyApplyFormula(
+            formula,
+            ctx,
+            data,
+            currentArgs,
+            currentPackage,
+            currentPath,
+          ),
+        )
       }
       default:
         if (_ctx.env?.logErrors) {

--- a/packages/core/src/formula/functionFormula.ts
+++ b/packages/core/src/formula/functionFormula.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+import type { ComponentData } from '../component/component.types'
 import type { FormulaHandler, Toddle } from '../types'
 import { measure } from '../utils/measure'
 import { isDefined } from '../utils/util'
@@ -12,52 +13,69 @@ import {
 export const applyFunctionFormula = (
   formula: FunctionOperation,
   ctx: FormulaContext,
+  data: ComponentData,
+  currentArgs: any,
+  currentPackage: string | null | undefined,
+  jsonPath: Array<string | number> | undefined,
+  // eslint-disable-next-line max-params
 ) => {
-  const stopMeasure = measure(`Formula: ${formula.name}`, {
-    formula,
-    component: ctx.component?.name,
-  })
-  const packageName = formula.package ?? ctx.package ?? undefined
+  const stopMeasure = measure(() => [
+    `Formula: ${formula.name}`,
+    {
+      formula,
+      component: ctx.component?.name,
+    },
+  ])
+  const packageName = formula.package ?? currentPackage ?? undefined
   const newFunc = (
     ctx.toddle ??
     ((globalThis as any).toddle as Toddle<unknown, unknown> | undefined)
   )?.getCustomFormula(formula.name, packageName)
   if (isDefined(newFunc)) {
-    ctx.package = packageName
-    const args = (formula.arguments ?? []).reduce<Record<string, unknown>>(
-      (args, arg, i) => ({
-        ...args,
-        [arg.name ?? `${i}`]: arg.isFunction
-          ? (Args: any) =>
-              applyFormula(
-                arg.formula,
-                {
-                  ...ctx,
-                  data: {
-                    ...ctx.data,
-                    Args: ctx.data.Args
-                      ? { ...Args, '@toddle.parent': ctx.data.Args }
-                      : Args,
-                  },
-                },
-                ['arguments', i],
-              )
-          : applyFormula(arg.formula, ctx, ['arguments', i]),
-      }),
-      {},
-    )
+    const fnArgs: Record<string, unknown> = {}
+    const formulaArguments = formula.arguments ?? []
+    for (let i = 0; i < formulaArguments.length; i++) {
+      const arg = formulaArguments[i]
+      if (!arg) {
+        continue
+      }
+      const name = arg.name ?? `${i}`
+      fnArgs[name] = arg.isFunction
+        ? (nestedArgs: any) =>
+            applyFormula(
+              arg.formula,
+              ctx,
+              data,
+              currentArgs
+                ? { ...nestedArgs, '@toddle.parent': currentArgs }
+                : nestedArgs,
+              packageName,
+              jsonPath,
+              ['arguments', i],
+            )
+        : applyFormula(
+            arg.formula,
+            ctx,
+            data,
+            currentArgs,
+            packageName,
+            jsonPath,
+            ['arguments', i],
+          )
+    }
     try {
       if (isToddleFormula(newFunc)) {
         return applyFormula(
           newFunc.formula,
-          {
-            ...ctx,
-            data: { ...ctx.data, Args: args },
-          },
+          ctx,
+          data,
+          fnArgs,
+          packageName,
+          jsonPath,
           ['formula'],
         )
       } else {
-        return newFunc.handler(args, {
+        return newFunc.handler(fnArgs, {
           root: ctx.root ?? document,
           env: ctx.env,
         } as any)
@@ -69,7 +87,7 @@ export const applyFunctionFormula = (
       }
       return null
     } finally {
-      stopMeasure()
+      stopMeasure?.()
     }
   } else {
     // Lookup legacy formula
@@ -77,26 +95,41 @@ export const applyFunctionFormula = (
       ctx.toddle ?? ((globalThis as any).toddle as Toddle<unknown, unknown>)
     ).getFormula(formula.name)
     if (typeof legacyFunc === 'function') {
-      const args = (formula.arguments ?? []).map((arg, i) =>
-        arg.isFunction
-          ? (Args: any) =>
-              applyFormula(
+      const legacyArgs: any[] = []
+      const formulaArguments = formula.arguments ?? []
+      for (let i = 0; i < formulaArguments.length; i++) {
+        const arg = formulaArguments[i]
+        if (!arg) {
+          legacyArgs.push(undefined)
+          continue
+        }
+        legacyArgs.push(
+          arg.isFunction
+            ? (nestedArgs: any) =>
+                applyFormula(
+                  arg.formula,
+                  ctx,
+                  data,
+                  currentArgs
+                    ? { ...nestedArgs, '@toddle.parent': currentArgs }
+                    : nestedArgs,
+                  currentPackage,
+                  jsonPath,
+                  ['arguments', i],
+                )
+            : applyFormula(
                 arg.formula,
-                {
-                  ...ctx,
-                  data: {
-                    ...ctx.data,
-                    Args: ctx.data.Args
-                      ? { ...Args, '@toddle.parent': ctx.data.Args }
-                      : Args,
-                  },
-                },
+                ctx,
+                data,
+                currentArgs,
+                currentPackage,
+                jsonPath,
                 ['arguments', i],
-              )
-          : applyFormula(arg.formula, ctx, ['arguments', i]),
-      )
+              ),
+        )
+      }
       try {
-        return legacyFunc(args, ctx as any)
+        return legacyFunc(legacyArgs, ctx as any)
       } catch (e) {
         ctx.toddle.errors.push(e as Error)
         if (ctx.env?.logErrors) {
@@ -104,7 +137,7 @@ export const applyFunctionFormula = (
         }
         return null
       } finally {
-        stopMeasure()
+        stopMeasure?.()
       }
     }
   }

--- a/packages/core/src/formula/objectFormula.ts
+++ b/packages/core/src/formula/objectFormula.ts
@@ -1,3 +1,4 @@
+import type { ComponentData } from '../component/component.types'
 import {
   applyFormula,
   type FormulaContext,
@@ -7,11 +8,19 @@ import {
 export const applyObjectFormula = (
   formula: ObjectOperation,
   ctx: FormulaContext,
+  data: ComponentData,
+  args: any,
+  packageName: string | null | undefined,
+  jsonPath: Array<string | number> | undefined,
 ) => {
   return Object.fromEntries(
     formula.arguments?.map((entry, i) => [
       entry.name,
-      applyFormula(entry.formula, ctx, ['arguments', i, 'formula']),
+      applyFormula(entry.formula, ctx, data, args, packageName, jsonPath, [
+        'arguments',
+        i,
+        'formula',
+      ]),
     ]) ?? [],
   )
 }

--- a/packages/core/src/formula/orFormula.ts
+++ b/packages/core/src/formula/orFormula.ts
@@ -1,11 +1,25 @@
+import type { ComponentData } from '../component/component.types'
 import { toBoolean } from '../utils/util'
 import { applyFormula, type FormulaContext, type OrOperation } from './formula'
 
-export const applyOrFormula = (formula: OrOperation, ctx: FormulaContext) => {
+export const applyOrFormula = (
+  formula: OrOperation,
+  ctx: FormulaContext,
+  data: ComponentData,
+  args: any,
+  packageName: string | null | undefined,
+  jsonPath: Array<string | number> | undefined,
+) => {
   for (let i = 0; i < (formula.arguments ?? []).length; i++) {
     const arg = (formula.arguments ?? [])[i]
     if (
-      toBoolean(applyFormula(arg?.formula, ctx, ['arguments', i, 'formula']))
+      toBoolean(
+        applyFormula(arg?.formula, ctx, data, args, packageName, jsonPath, [
+          'arguments',
+          i,
+          'formula',
+        ]),
+      )
     ) {
       return true
     }
@@ -16,15 +30,23 @@ export const applyOrFormula = (formula: OrOperation, ctx: FormulaContext) => {
 export const applyEvaluateAllOrFormula = (
   formula: OrOperation,
   ctx: FormulaContext,
+  data: ComponentData,
+  args: any,
+  packageName: string | null | undefined,
+  jsonPath: Array<string | number> | undefined,
 ) => {
   let orResult = false
   for (let i = 0; i < (formula.arguments ?? []).length; i++) {
     const arg = (formula.arguments ?? [])[i]
-    const argResult = applyFormula(arg?.formula, ctx, [
-      'arguments',
-      i,
-      'formula',
-    ])
+    const argResult = applyFormula(
+      arg?.formula,
+      ctx,
+      data,
+      args,
+      packageName,
+      jsonPath,
+      ['arguments', i, 'formula'],
+    )
     if (toBoolean(argResult)) {
       orResult = true
     }

--- a/packages/core/src/formula/pathFormula.test.ts
+++ b/packages/core/src/formula/pathFormula.test.ts
@@ -32,4 +32,11 @@ describe('applyPathFormula', () => {
     const data: any = { arr: [10, 20, 30] }
     expect(applyPathFormula(formula, data)).toBe(20)
   })
+
+  it('resolves Args from the args parameter', () => {
+    const formula: PathOperation = { type: 'path', path: ['Args', 'val'] }
+    const data: any = {}
+    const args = { val: 'hello' }
+    expect(applyPathFormula(formula, data, args)).toBe('hello')
+  })
 })

--- a/packages/core/src/formula/pathFormula.ts
+++ b/packages/core/src/formula/pathFormula.ts
@@ -1,13 +1,18 @@
-import type { FormulaContext, PathOperation } from './formula'
+import type { ComponentData } from '../component/component.types'
+import type { PathOperation } from './formula'
 
 export const applyPathFormula = (
   formula: PathOperation,
-  data: FormulaContext['data'],
+  data: ComponentData,
+  args?: any,
 ) => {
   let input: any = data
-  for (const key of formula.path) {
-    if (input && typeof input === 'object') {
-      input = input[key]
+  for (let i = 0; i < formula.path.length; i++) {
+    const key = formula.path[i]!
+    if (i === 0 && key === 'Args') {
+      input = args
+    } else if (input && typeof input === 'object') {
+      input = (input as any)[key]
     } else {
       return null
     }

--- a/packages/core/src/formula/recordFormula.ts
+++ b/packages/core/src/formula/recordFormula.ts
@@ -1,3 +1,4 @@
+import type { ComponentData } from '../component/component.types'
 import {
   applyFormula,
   type FormulaContext,
@@ -7,11 +8,19 @@ import {
 export const applyRecordFormula = (
   formula: RecordOperation,
   ctx: FormulaContext,
+  data: ComponentData,
+  args: any,
+  packageName: string | null | undefined,
+  jsonPath: Array<string | number> | undefined,
 ) => {
   return Object.fromEntries(
     (formula.entries ?? []).map((entry, i) => [
       entry.name,
-      applyFormula(entry.formula, ctx, ['entries', i, 'formula']),
+      applyFormula(entry.formula, ctx, data, args, packageName, jsonPath, [
+        'entries',
+        i,
+        'formula',
+      ]),
     ]),
   )
 }

--- a/packages/core/src/formula/switchFormula.ts
+++ b/packages/core/src/formula/switchFormula.ts
@@ -1,3 +1,4 @@
+import type { ComponentData } from '../component/component.types'
 import { toBoolean } from '../utils/util'
 import {
   applyFormula,
@@ -8,44 +9,86 @@ import {
 export const applySwitchFormula = (
   formula: SwitchOperation,
   ctx: FormulaContext,
+  data: ComponentData,
+  args: any,
+  packageName: string | null | undefined,
+  jsonPath: Array<string | number> | undefined,
 ) => {
   // Evaluates cases until one matches
   for (let i = 0; i < (formula.cases ?? []).length; i++) {
     const switchCase = (formula.cases ?? [])[i]
     if (
       toBoolean(
-        applyFormula(switchCase?.condition, ctx, ['cases', i, 'condition']),
+        applyFormula(
+          switchCase?.condition,
+          ctx,
+          data,
+          args,
+          packageName,
+          jsonPath,
+          ['cases', i, 'condition'],
+        ),
       )
     ) {
-      return applyFormula(switchCase?.formula, ctx, ['cases', i, 'formula'])
+      return applyFormula(
+        switchCase?.formula,
+        ctx,
+        data,
+        args,
+        packageName,
+        jsonPath,
+        ['cases', i, 'formula'],
+      )
     }
   }
-  return applyFormula(formula.default, ctx, ['default'])
+  return applyFormula(formula.default, ctx, data, args, packageName, jsonPath, [
+    'default',
+  ])
 }
 
 export const applyEvaluateAllSwitchFormula = (
   formula: SwitchOperation,
   ctx: FormulaContext,
+  data: ComponentData,
+  args: any,
+  packageName: string | null | undefined,
+  jsonPath: Array<string | number> | undefined,
 ) => {
   // Evaluate all cases and the default, but only returns the first matching case or the default
   let switchResult: { match: true; value: any } | null = null
   for (let i = 0; i < (formula.cases ?? []).length; i++) {
     const switchCase = (formula.cases ?? [])[i]
-    const conditionValue = applyFormula(switchCase?.condition, ctx, [
-      'cases',
-      i,
-      'condition',
-    ])
-    const formulaValue = applyFormula(switchCase?.formula, ctx, [
-      'cases',
-      i,
-      'formula',
-    ])
+    const conditionValue = applyFormula(
+      switchCase?.condition,
+      ctx,
+      data,
+      args,
+      packageName,
+      jsonPath,
+      ['cases', i, 'condition'],
+    )
+    const formulaValue = applyFormula(
+      switchCase?.formula,
+      ctx,
+      data,
+      args,
+      packageName,
+      jsonPath,
+      ['cases', i, 'formula'],
+    )
     if (toBoolean(conditionValue) && switchResult === null) {
       switchResult = { match: true, value: formulaValue }
     }
   }
-  const defaultValue = applyFormula(formula.default, ctx, ['default'])
+  const defaultValue = applyFormula(
+    formula.default,
+    ctx,
+    data,
+    args,
+    packageName,
+    jsonPath,
+    ['default'],
+  )
   if (switchResult !== null) {
     return switchResult.value
   } else {

--- a/packages/core/src/utils/measure.ts
+++ b/packages/core/src/utils/measure.ts
@@ -22,24 +22,24 @@ globalScope.__nc_enableMeasure = (enabled = true, maxDepth = 10) => {
 
 let measureCount = 0
 const STACK: string[] = []
-const NOOP = () => {}
 
 export const measure = (
-  key: string,
-  details: Record<string, unknown>,
-  type?: 'component',
+  args: () =>
+    | [string, Record<string, unknown>]
+    | [string, Record<string, unknown>, 'component'],
 ) => {
   if (!globalScope.__nc_measure_enabled) {
-    return NOOP
+    return
   }
 
+  const [key, details, type] = args()
   const selfIndex = measureCount++
   const selfStackSize = STACK.length
   if (selfStackSize >= globalScope.__nc_measure_max_depth) {
-    return NOOP
+    return
   }
   if (STACK.length >= globalScope.__nc_measure_max_depth) {
-    return NOOP
+    return
   }
 
   const start = performance.now() + selfStackSize * 0.001

--- a/packages/runtime/src/components/createComponent.ts
+++ b/packages/runtime/src/components/createComponent.ts
@@ -67,6 +67,7 @@ export function createComponent({
     return []
   }
   const formulaCtx = {
+    data: dataSignal.get(),
     component: ctx.component,
     formulaCache: ctx.formulaCache,
     root: ctx.root,
@@ -81,10 +82,11 @@ export function createComponent({
       value?.type !== 'value'
         ? applyFormula(
             value,
-            {
-              ...formulaCtx,
-              data,
-            },
+            formulaCtx,
+            data,
+            undefined,
+            undefined,
+            undefined,
             ['attrs', attr],
           )
         : value?.value,
@@ -107,8 +109,11 @@ export function createComponent({
               {
                 ...formulaCtx,
                 component,
-                data: dataSignal.get(),
               },
+              dataSignal.get(),
+              undefined,
+              undefined,
+              undefined,
               ['apis', name, 'autoFetch'],
             )
               ? true
@@ -133,6 +138,7 @@ export function createComponent({
 
   // Subscribe context before calculating variable initial values to ensure they can reference context values
   subscribeToContext(componentDataSignal, component, ctx)
+  const childFormulaCtx = { ...formulaCtx, component }
   componentDataSignal.update((data) => ({
     ...data,
     Variables: mapObject(
@@ -144,12 +150,11 @@ export function createComponent({
         name,
         applyFormula(
           variable.initialValue,
-          {
-            // Initial value
-            ...formulaCtx,
-            component,
-            data: componentDataSignal.get(),
-          },
+          childFormulaCtx,
+          componentDataSignal.get(),
+          undefined,
+          undefined,
+          undefined,
           ['variables', name],
         ),
       ],
@@ -359,10 +364,11 @@ export function createComponent({
           appendUnit(
             applyFormula(
               customProperty.formula,
-              {
-                ...formulaCtx,
-                data,
-              },
+              formulaCtx,
+              data,
+              undefined,
+              undefined,
+              undefined,
               ['customProperties', customPropertyName, 'formula'],
             ),
             customProperty.unit,
@@ -386,10 +392,11 @@ export function createComponent({
             appendUnit(
               applyFormula(
                 customProperty.formula,
-                {
-                  ...formulaCtx,
-                  data,
-                },
+                formulaCtx,
+                data,
+                undefined,
+                undefined,
+                undefined,
                 ['customProperties', customPropertyName, 'formula'],
               ),
               customProperty.unit,

--- a/packages/runtime/src/components/createElement.ts
+++ b/packages/runtime/src/components/createElement.ts
@@ -57,6 +57,7 @@ export function createElement({
     : document.createElement(tag)
 
   const formulaCtx = {
+    data: dataSignal.get(),
     component: ctx.component,
     formulaCache: ctx.formulaCache,
     root: ctx.root,
@@ -82,12 +83,7 @@ export function createElement({
     Object.entries(node.classes)?.forEach(([className, { formula }]) => {
       if (formula) {
         const classSignal = dataSignal.map((data) =>
-          toBoolean(
-            applyFormula(formula, {
-              ...formulaCtx,
-              data,
-            }),
-          ),
+          toBoolean(applyFormula(formula, formulaCtx, data)),
         )
         classSignal.subscribe((show) =>
           show
@@ -122,10 +118,11 @@ export function createElement({
         o = dataSignal.map((data) => {
           const val = applyFormula(
             value,
-            {
-              ...formulaCtx,
-              data,
-            },
+            formulaCtx,
+            data,
+            undefined,
+            undefined,
+            undefined,
             attrPath,
           )
           ctx.reportFormulaEvaluation?.(attrPath, val, ctx)
@@ -159,10 +156,11 @@ export function createElement({
     const signal = dataSignal.map((data) => {
       const value = applyFormula(
         formula,
-        {
-          ...formulaCtx,
-          data,
-        },
+        formulaCtx,
+        data,
+        undefined,
+        undefined,
+        undefined,
         styleVarPath,
       )
       ctx.reportFormulaEvaluation?.(styleVarPath, value, ctx)
@@ -194,10 +192,11 @@ export function createElement({
         signal: dataSignal.map((data) => {
           const val = applyFormula(
             formula,
-            {
-              ...formulaCtx,
-              data,
-            },
+            formulaCtx,
+            data,
+            undefined,
+            undefined,
+            undefined,
             cpPath,
           )
           ctx.reportFormulaEvaluation?.(cpPath, val, ctx)
@@ -230,10 +229,11 @@ export function createElement({
           signal: dataSignal.map((data) => {
             const val = applyFormula(
               formula,
-              {
-                ...formulaCtx,
-                data,
-              },
+              formulaCtx,
+              data,
+              undefined,
+              undefined,
+              undefined,
               variantCpPath,
             )
             ctx.reportFormulaEvaluation?.(variantCpPath, val, ctx)
@@ -279,12 +279,7 @@ export function createElement({
           textValues.push(String(node.value.value))
         } else {
           const textSignal = dataSignal.map((data) => {
-            return String(
-              applyFormula(node.value, {
-                ...formulaCtx,
-                data,
-              }),
-            )
+            return String(applyFormula(node.value, formulaCtx, data))
           })
           textValues.push(textSignal)
         }

--- a/packages/runtime/src/components/createNode.ts
+++ b/packages/runtime/src/components/createNode.ts
@@ -89,26 +89,29 @@ export function createNode({
   }: NodeRenderer<NodeModel>): ReadonlyArray<Element | Text> {
     let firstRun = true
     let childDataSignal: Signal<ComponentData> | null = null
+    const formulaCtx = {
+      component: ctx.component,
+      formulaCache: ctx.formulaCache,
+      root: ctx.root,
+      package: ctx.package,
+      toddle: ctx.toddle,
+      env: ctx.env,
+      jsonPath: ctx.jsonPath,
+      reportFormulaEvaluation: ctx.reportFormulaEvaluation,
+    }
     const showSignal = dataSignal.map((data) => {
       const conditionPath = ['nodes', id, 'condition']
       const show = toBoolean(
         applyFormula(
           node.condition,
-          {
-            data,
-            component: ctx.component,
-            formulaCache: ctx.formulaCache,
-            root: ctx.root,
-            package: ctx.package,
-            toddle: ctx.toddle,
-            env: ctx.env,
-            jsonPath: ctx.jsonPath,
-            reportFormulaEvaluation: ctx.reportFormulaEvaluation,
-          },
+          formulaCtx as any,
+          data,
+          undefined,
+          undefined,
+          undefined,
           conditionPath,
         ),
       )
-
       return show
     })
 
@@ -196,19 +199,23 @@ export function createNode({
         elements: ReadonlyArray<Element | Text>
       }
     >()
+    const formulaCtx = {
+      component: ctx.component,
+      formulaCache: ctx.formulaCache,
+      root: ctx.root,
+      package: ctx.package,
+      toddle: ctx.toddle,
+      env: ctx.env,
+    }
     const repeatSignal = dataSignal.map((data) => {
       const listPath = ['nodes', id, 'repeat']
       const list = applyFormula(
         node?.repeat,
-        {
-          data,
-          component: ctx.component,
-          formulaCache: ctx.formulaCache,
-          root: ctx.root,
-          package: ctx.package,
-          toddle: ctx.toddle,
-          env: ctx.env,
-        },
+        formulaCtx as any,
+        data,
+        undefined,
+        undefined,
+        undefined,
         listPath,
       )
 
@@ -241,15 +248,11 @@ export function createNode({
           let childKey = node?.repeatKey
             ? applyFormula(
                 node.repeatKey,
-                {
-                  data: childData,
-                  component: ctx.component,
-                  formulaCache: ctx.formulaCache,
-                  root: ctx.root,
-                  package: ctx.package,
-                  toddle: ctx.toddle,
-                  env: ctx.env,
-                },
+                formulaCtx as any,
+                childData,
+                undefined,
+                undefined,
+                undefined,
                 repeatKeyPath,
               )
             : Key

--- a/packages/runtime/src/components/renderComponent.ts
+++ b/packages/runtime/src/components/renderComponent.ts
@@ -79,14 +79,14 @@ export function renderComponent({
   jsonPath,
   reportFormulaEvaluation,
 }: RenderComponentProps): ReadonlyArray<Element | Text> {
-  const stopMeasure = measure(
+  const stopMeasure = measure(() => [
     `Render component: ${component.name}`,
     {
       component: component.name,
       path,
     },
     'component',
-  )
+  ])
   const ctx: ComponentContext = {
     triggerEvent: onEvent,
     component,
@@ -161,6 +161,6 @@ export function renderComponent({
       void handleAction(action, dataSignal.get(), ctx)
     })
   })
-  stopMeasure()
+  stopMeasure?.()
   return rootElem
 }

--- a/packages/ssr/src/rendering/attributes.ts
+++ b/packages/ssr/src/rendering/attributes.ts
@@ -60,15 +60,22 @@ export function getNodeAttrs({
   toddle: FormulaContext['toddle']
 }) {
   const { style, ...restAttrs } = node.attrs ?? {}
+  const formulaContext: FormulaContext = {
+    data,
+    component,
+    package: packageName ?? null,
+    env,
+    toddle,
+  }
   const nodeAttrs = Object.entries(restAttrs).reduce<string[]>(
     (appliedAttributes, [name, attrValue]) => {
-      const value = applyFormula(attrValue, {
+      const value = applyFormula(
+        attrValue,
+        formulaContext,
         data,
-        component,
-        package: packageName,
-        env,
-        toddle,
-      })
+        undefined,
+        packageName,
+      )
       if (toBoolean(value)) {
         appliedAttributes.push(`${name}="${escapeAttrValue(value)}"`)
       }
@@ -80,13 +87,13 @@ export function getNodeAttrs({
     (styleVariable) => {
       return `--${styleVariable.name}: ${
         String(
-          applyFormula(styleVariable.formula, {
+          applyFormula(
+            styleVariable.formula,
+            formulaContext,
             data,
-            component,
-            package: packageName,
-            env,
-            toddle,
-          }),
+            undefined,
+            packageName,
+          ),
         ) + (styleVariable.unit ?? '')
       }`
     },
@@ -95,15 +102,7 @@ export function getNodeAttrs({
   // Handle the style-attribute independently to merge with style variables
   const styles = [
     ...(style
-      ? [
-          applyFormula(style, {
-            data,
-            component,
-            package: packageName,
-            env,
-            toddle,
-          }),
-        ]
+      ? [applyFormula(style, formulaContext, data, undefined, packageName)]
       : []),
     ...styleVariables,
   ]


### PR DESCRIPTION
Super draft PR, will need much more work, but the general idea is to use function arguments for arguments that change often and only use the ctx objects for properties that are static or rarely change. This reduce object destruct and construct over and over. Formulas can easily run 10.000s of times for smaller UI changes. Allocating new objects each time has a penalty upfront and overhead in garbage-collection.

Overall performance improvement for both server and client seems promising. Some random actions in the editor project fro example seems ~20% faster and there is more to come for.