### PR TITLE
Use fast-equals instead of fast-deep-equal

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -68,7 +68,6 @@
       "name": "@nordcraft/std-lib",
       "dependencies": {
         "@nordcraft/core": "workspace:*",
-        "fast-deep-equal": "3.1.3",
         "fast-equals": "6.0.2",
       },
       "devDependencies": {
@@ -81,7 +80,6 @@
       "dependencies": {
         "@nordcraft/core": "workspace:*",
         "@nordcraft/std-lib": "workspace:*",
-        "fast-deep-equal": "3.1.3",
         "fast-equals": "6.0.2",
         "path-to-regexp": "6.3.0",
       },
@@ -91,7 +89,7 @@
       "dependencies": {
         "@nordcraft/core": "workspace:*",
         "@nordcraft/ssr": "workspace:*",
-        "fast-deep-equal": "3.1.3",
+        "fast-equals": "6.0.2",
         "jsondiffpatch": "0.7.3",
         "postcss": "8.5.8",
         "zod": "4.2.1",
@@ -103,7 +101,6 @@
         "@nordcraft/core": "workspace:*",
         "@nordcraft/std-lib": "workspace:*",
         "cookie": "1.0.2",
-        "fast-deep-equal": "3.1.3",
         "fast-equals": "6.0.2",
         "xss": "1.0.15",
       },

--- a/bun.lock
+++ b/bun.lock
@@ -69,6 +69,7 @@
       "dependencies": {
         "@nordcraft/core": "workspace:*",
         "fast-deep-equal": "3.1.3",
+        "fast-equals": "6.0.2",
       },
       "devDependencies": {
         "@types/node": "26.1.0",
@@ -81,6 +82,7 @@
         "@nordcraft/core": "workspace:*",
         "@nordcraft/std-lib": "workspace:*",
         "fast-deep-equal": "3.1.3",
+        "fast-equals": "6.0.2",
         "path-to-regexp": "6.3.0",
       },
     },
@@ -102,6 +104,7 @@
         "@nordcraft/std-lib": "workspace:*",
         "cookie": "1.0.2",
         "fast-deep-equal": "3.1.3",
+        "fast-equals": "6.0.2",
         "xss": "1.0.15",
       },
     },
@@ -448,6 +451,8 @@
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-equals": ["fast-equals@6.0.2", "", {}, "sha512-sAjhj9ZhOxYCGiNMnZLaucOqf5ZeFnHNoKoAZiD9thhJ0N8RP85qJK759/97C/3L7NzzmGVB5uiX9AUpySZmUQ=="],
 
     "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
 

--- a/packages/lib/formulas/Id/handler.test.ts
+++ b/packages/lib/formulas/Id/handler.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import isEqual from 'fast-deep-equal'
+import { deepEqual as isEqual } from 'fast-equals'
 import handler from './handler'
 ;(globalThis as any).toddle = { isEqual }
 

--- a/packages/lib/formulas/encodeJSON/handler.test.ts
+++ b/packages/lib/formulas/encodeJSON/handler.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import isEqual from 'fast-deep-equal'
+import { deepEqual as isEqual } from 'fast-equals'
 import handler from './handler'
 ;(globalThis as any).toddle = { isEqual }
 

--- a/packages/lib/formulas/equals/handler.test.ts
+++ b/packages/lib/formulas/equals/handler.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import isEqual from 'fast-deep-equal'
+import { deepEqual as isEqual } from 'fast-equals'
 import handler from './handler'
 ;(globalThis as any).toddle = { isEqual }
 

--- a/packages/lib/formulas/includes/handler.test.ts
+++ b/packages/lib/formulas/includes/handler.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, test } from 'bun:test'
+import { deepEqual as isEqual } from 'fast-equals'
 import handler from './handler'
-
-import fastDeepEqual from 'fast-deep-equal'
-;(globalThis as any).toddle = { isEqual: fastDeepEqual }
+;(globalThis as any).toddle = { isEqual }
 
 describe('Formula: Includes', () => {
   test('should return null if collection is neither string nor array', () => {

--- a/packages/lib/formulas/indexOf/handler.test.ts
+++ b/packages/lib/formulas/indexOf/handler.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from 'bun:test'
 import handler from './handler'
 
-import fastDeepEqual from 'fast-deep-equal'
-;(globalThis as any).toddle = { isEqual: fastDeepEqual }
+import { deepEqual as isEqual } from 'fast-equals'
+;(globalThis as any).toddle = { isEqual }
 
 describe('Formula: Index of', () => {
   test('should return null if collection is neither string nor array', () => {

--- a/packages/lib/formulas/join/handler.test.ts
+++ b/packages/lib/formulas/join/handler.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import handler from './handler'
-
-import fastDeepEqual from 'fast-deep-equal'
-;(globalThis as any).toddle = { isEqual: fastDeepEqual }
+;(globalThis as any).toddle = { isEqual }
 
 describe('Formula: Join', () => {
   test('should return null if collection is not an array', () => {

--- a/packages/lib/formulas/json/handler.test.ts
+++ b/packages/lib/formulas/json/handler.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import handler from './handler'
-
-import fastDeepEqual from 'fast-deep-equal'
-;(globalThis as any).toddle = { isEqual: fastDeepEqual }
+;(globalThis as any).toddle = { isEqual }
 
 describe('Formula: JSON', () => {
   test('Should return a json string when given an object', () => {

--- a/packages/lib/formulas/lastIndexOf/handler.test.ts
+++ b/packages/lib/formulas/lastIndexOf/handler.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import handler from './handler'
-
-import fastDeepEqual from 'fast-deep-equal'
-;(globalThis as any).toddle = { isEqual: fastDeepEqual }
+;(globalThis as any).toddle = { isEqual }
 
 describe('Formula: Index of', () => {
   test('should return null if collection is neither string nor array', () => {

--- a/packages/lib/formulas/notEqual/handler.test.ts
+++ b/packages/lib/formulas/notEqual/handler.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import isEqual from 'fast-deep-equal'
+import { deepEqual as isEqual } from 'fast-equals'
 import handler from './handler'
 ;(globalThis as any).toddle = { isEqual }
 

--- a/packages/lib/formulas/number/handler.test.ts
+++ b/packages/lib/formulas/number/handler.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import isEqual from 'fast-deep-equal'
+import { deepEqual as isEqual } from 'fast-equals'
 import handler from './handler'
 ;(globalThis as any).toddle = { isEqual }
 

--- a/packages/lib/formulas/parseJSON/handler.test.ts
+++ b/packages/lib/formulas/parseJSON/handler.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import isEqual from 'fast-deep-equal'
+import { deepEqual as isEqual } from 'fast-equals'
 import handler from './handler'
 ;(globalThis as any).toddle = { isEqual }
 

--- a/packages/lib/formulas/parseURL/handler.test.ts
+++ b/packages/lib/formulas/parseURL/handler.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import isEqual from 'fast-deep-equal'
+import { deepEqual as isEqual } from 'fast-equals'
 import handler from './handler'
 ;(globalThis as any).toddle = { isEqual }
 

--- a/packages/lib/formulas/randomNumber/handler.test.ts
+++ b/packages/lib/formulas/randomNumber/handler.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import isEqual from 'fast-deep-equal'
+import { deepEqual as isEqual } from 'fast-equals'
 import handler from './handler'
 ;(globalThis as any).toddle = { isEqual }
 

--- a/packages/lib/formulas/range/handler.test.ts
+++ b/packages/lib/formulas/range/handler.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import isEqual from 'fast-deep-equal'
+import { deepEqual as isEqual } from 'fast-equals'
 import handler from './handler'
 ;(globalThis as any).toddle = { isEqual }
 

--- a/packages/lib/formulas/reduce/handler.test.ts
+++ b/packages/lib/formulas/reduce/handler.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import isEqual from 'fast-deep-equal'
+import { deepEqual as isEqual } from 'fast-equals'
 import handler from './handler'
 ;(globalThis as any).toddle = { isEqual }
 

--- a/packages/lib/formulas/reverse/handler.test.ts
+++ b/packages/lib/formulas/reverse/handler.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import isEqual from 'fast-deep-equal'
+import { deepEqual as isEqual } from 'fast-equals'
 import handler from './handler'
 ;(globalThis as any).toddle = { isEqual }
 

--- a/packages/lib/formulas/round/handler.test.ts
+++ b/packages/lib/formulas/round/handler.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import isEqual from 'fast-deep-equal'
+import { deepEqual as isEqual } from 'fast-equals'
 import handler from './handler'
 ;(globalThis as any).toddle = { isEqual }
 

--- a/packages/lib/formulas/squareRoot/handler.test.ts
+++ b/packages/lib/formulas/squareRoot/handler.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import handler from './handler'
-
-import fastDeepEqual from 'fast-deep-equal'
-;(globalThis as any).toddle = { isEqual: fastDeepEqual }
+;(globalThis as any).toddle = { isEqual }
 
 describe('Formula: Square root', () => {
   test('should return the square root', () => {

--- a/packages/lib/formulas/startsWith/handler.test.ts
+++ b/packages/lib/formulas/startsWith/handler.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import handler from './handler'
-
-import fastDeepEqual from 'fast-deep-equal'
-;(globalThis as any).toddle = { isEqual: fastDeepEqual }
+;(globalThis as any).toddle = { isEqual }
 
 describe('Formula: Starts with', () => {
   test('should return null if collection is neither string nor array', () => {

--- a/packages/lib/formulas/string/handler.test.ts
+++ b/packages/lib/formulas/string/handler.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import handler from './handler'
-
-import fastDeepEqual from 'fast-deep-equal'
-;(globalThis as any).toddle = { isEqual: fastDeepEqual }
+;(globalThis as any).toddle = { isEqual }
 
 describe('Formula: String', () => {
   test('should convert the input to a string', () => {

--- a/packages/lib/formulas/take/handler.test.ts
+++ b/packages/lib/formulas/take/handler.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import handler from './handler'
-
-import fastDeepEqual from 'fast-deep-equal'
-;(globalThis as any).toddle = { isEqual: fastDeepEqual }
+;(globalThis as any).toddle = { isEqual }
 
 describe('Formula: Take', () => {
   test('should return the first n elements', () => {

--- a/packages/lib/formulas/takeLast/handler.test.ts
+++ b/packages/lib/formulas/takeLast/handler.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import handler from './handler'
-
-import fastDeepEqual from 'fast-deep-equal'
-;(globalThis as any).toddle = { isEqual: fastDeepEqual }
+;(globalThis as any).toddle = { isEqual }
 
 describe('Formula: Take Last', () => {
   test('should return the first n elements', () => {

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -9,7 +9,7 @@
     "directory": "packages/lib"
   },
   "dependencies": {
-    "fast-deep-equal": "3.1.3",
+    "fast-equals": "6.0.2",
     "@nordcraft/core": "workspace:*"
   },
   "devDependencies": {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@nordcraft/core": "workspace:*",
     "@nordcraft/std-lib": "workspace:*",
-    "fast-deep-equal": "3.1.3",
+    "fast-equals": "6.0.2",
     "path-to-regexp": "6.3.0"
   },
   "scripts": {

--- a/packages/runtime/src/components/renderComponent.ts
+++ b/packages/runtime/src/components/renderComponent.ts
@@ -7,7 +7,7 @@ import type { ToddleEnv } from '@nordcraft/core/dist/formula/formula'
 import type { FormulaEvaluationReporter } from '@nordcraft/core/dist/formula/formulaTypes'
 import type { Toddle } from '@nordcraft/core/dist/types'
 import { measure } from '@nordcraft/core/dist/utils/measure'
-import fastDeepEqual from 'fast-deep-equal'
+import { deepEqual as isEqual } from 'fast-equals'
 import { handleAction } from '../events/handleAction'
 import type { Signal } from '../signal/signal'
 import type {
@@ -138,7 +138,7 @@ export function renderComponent({
                       [key, value],
                     ) => {
                       if (
-                        fastDeepEqual(value, prev![key]) === false &&
+                        isEqual(value, prev![key]) === false &&
                         component.attributes?.[key]?.name
                       ) {
                         changes[component.attributes?.[key]?.name] = {

--- a/packages/runtime/src/custom-element.main.ts
+++ b/packages/runtime/src/custom-element.main.ts
@@ -1,10 +1,10 @@
 import * as libActions from '@nordcraft/std-lib/dist/actions'
 import * as libFormulas from '@nordcraft/std-lib/dist/formulas'
-import fastDeepEqual from 'fast-deep-equal'
+import { deepEqual as isEqual } from 'fast-equals'
 import { defineComponents } from './custom-element/defineComponents'
 
 const loadCorePlugins = (toddle = window.toddle) => {
-  toddle.isEqual = fastDeepEqual
+  toddle.isEqual = isEqual
 
   // load default formulas and actions
   Object.entries(libFormulas).forEach(([name, module]) =>

--- a/packages/runtime/src/editor-preview.main.ts
+++ b/packages/runtime/src/editor-preview.main.ts
@@ -60,7 +60,7 @@ import { safeFunctionName } from '@nordcraft/core/dist/utils/handlerUtils'
 import { isDefined } from '@nordcraft/core/dist/utils/util'
 import * as libActions from '@nordcraft/std-lib/dist/actions'
 import * as libFormulas from '@nordcraft/std-lib/dist/formulas'
-import fastDeepEqual from 'fast-deep-equal'
+import { deepEqual as isEqual } from 'fast-equals'
 import { createLegacyAPI } from './api/createAPI'
 import { createAPI } from './api/createAPIv2'
 import { createNode } from './components/createNode'
@@ -135,7 +135,7 @@ export const initGlobalObject = () => {
     const legacyFormulas: Record<string, FormulaHandler | undefined> = {}
     const argumentInputDataList: Record<string, ArgumentInputDataFunction> = {}
     const toddle: Toddle<LocationSignal, PreviewShowSignal> = {
-      isEqual: fastDeepEqual,
+      isEqual,
       errors: [],
       formulas: {},
       actions: {},
@@ -520,8 +520,7 @@ export const createRoot = (
         case 'attrs': {
           if (
             message.data.attrs &&
-            fastDeepEqual(message.data.attrs, dataSignal.get().Attributes) ===
-              false
+            isEqual(message.data.attrs, dataSignal.get().Attributes) === false
           ) {
             const attrs = message.data.attrs
             dataSignal.update((data) => {
@@ -1297,9 +1296,7 @@ body[data-mode="design"] [data-id="${animationState.animatedElementId}"], body[d
 
     const scrollStateRestorer = storeScrollState()
     let { Attributes, Variables, Contexts } = dataSignal.get()
-    if (
-      fastDeepEqual(ctx?.component.attributes, _component.attributes) === false
-    ) {
+    if (isEqual(ctx?.component.attributes, _component.attributes) === false) {
       Attributes = mapObject(
         filterObject<Nullable<ComponentAttribute>, ComponentAttribute>(
           _component.attributes ?? {},
@@ -1310,7 +1307,7 @@ body[data-mode="design"] [data-id="${animationState.animatedElementId}"], body[d
     }
     if (
       _component.route &&
-      fastDeepEqual(ctx?.component.route, _component.route) === false
+      isEqual(ctx?.component.route, _component.route) === false
     ) {
       // Subscribe to the route signal so we can preview URL parameter changes in the editor
       routeSignal?.destroy()
@@ -1359,7 +1356,7 @@ body[data-mode="design"] [data-id="${animationState.animatedElementId}"], body[d
       )
     }
     if (
-      fastDeepEqual(
+      isEqual(
         ctx?.component.route?.info?.meta,
         _component.route?.info?.meta,
       ) === false ||
@@ -1376,7 +1373,7 @@ body[data-mode="design"] [data-id="${animationState.animatedElementId}"], body[d
         reportFormulaEvaluation,
       })
     }
-    if (fastDeepEqual(_component.contexts, ctx?.component.contexts) === false) {
+    if (isEqual(_component.contexts, ctx?.component.contexts) === false) {
       Contexts = (function createStaticContextFromComponent(
         component: Component,
         contextProvidersCreated?: Set<string>,
@@ -1485,9 +1482,7 @@ body[data-mode="design"] [data-id="${animationState.animatedElementId}"], body[d
         )
       })(_component)
     }
-    if (
-      fastDeepEqual(_component.variables, ctx?.component.variables) === false
-    ) {
+    if (isEqual(_component.variables, ctx?.component.variables) === false) {
       Variables = mapObject(
         filterObject<Nullable<ComponentVariable>, ComponentVariable>(
           _component.variables ?? {},
@@ -1540,7 +1535,7 @@ body[data-mode="design"] [data-id="${animationState.animatedElementId}"], body[d
     }
 
     if (
-      fastDeepEqual(
+      isEqual(
         newCtx.component.route?.info?.theme,
         ctx?.component.route?.info?.theme,
       ) === false
@@ -1561,7 +1556,7 @@ body[data-mode="design"] [data-id="${animationState.animatedElementId}"], body[d
       const previousApiInstance = ctx?.component.apis?.[api]
       if (isLegacyApi(apiInstance)) {
         if (
-          fastDeepEqual(
+          isEqual(
             omitKeys(apiInstance, ['onCompleted', 'onFailed']),
             previousApiInstance && isLegacyApi(previousApiInstance)
               ? omitKeys(previousApiInstance, ['onCompleted', 'onFailed'])
@@ -1603,9 +1598,8 @@ body[data-mode="design"] [data-id="${animationState.animatedElementId}"], body[d
 
     if (
       forceRerender ||
-      fastDeepEqual(newCtx.component.nodes, ctx?.component?.nodes) === false ||
-      fastDeepEqual(newCtx.component.formulas, ctx?.component?.formulas) ===
-        false
+      isEqual(newCtx.component.nodes, ctx?.component?.nodes) === false ||
+      isEqual(newCtx.component.formulas, ctx?.component?.formulas) === false
     ) {
       updateStyle(newCtx.component)
 
@@ -1834,8 +1828,8 @@ body[data-mode="design"] [data-id="${animationState.animatedElementId}"], body[d
     const selectionRect = getRectData(getDOMNodeFromNodeId(selectedNodeId))
     const highlightRect = getRectData(getDOMNodeFromNodeId(highlightedNodeId))
 
-    const selectionChanged = !fastDeepEqual(prevSelectionRect, selectionRect)
-    const highlightChanged = !fastDeepEqual(prevHighlightRect, highlightRect)
+    const selectionChanged = !isEqual(prevSelectionRect, selectionRect)
+    const highlightChanged = !isEqual(prevHighlightRect, highlightRect)
 
     if (selectionChanged || highlightChanged) {
       prevSelectionRect = selectionRect

--- a/packages/runtime/src/events/handleAction.ts
+++ b/packages/runtime/src/events/handleAction.ts
@@ -11,7 +11,7 @@ import {
 } from '@nordcraft/core/dist/formula/formula'
 import { mapObject, omitKeys } from '@nordcraft/core/dist/utils/collections'
 import { isDefined, toBoolean } from '@nordcraft/core/dist/utils/util'
-import fastDeepEqual from 'fast-deep-equal'
+import { deepEqual as isEqual } from 'fast-equals'
 import { isContextApiV2 } from '../api/apiUtils'
 import type { ComponentContext, Location } from '../types'
 import { getLocationUrl } from '../utils/url'
@@ -262,7 +262,7 @@ export function handleAction(
               ...queryUpdates,
             },
           }
-          if (fastDeepEqual(newLocation, current)) {
+          if (isEqual(newLocation, current)) {
             // No path/query parameter matched
             return current
           }

--- a/packages/runtime/src/page.main.ts
+++ b/packages/runtime/src/page.main.ts
@@ -24,7 +24,7 @@ import { VOID_HTML_ELEMENTS } from '@nordcraft/core/dist/utils/html'
 import { isDefined } from '@nordcraft/core/dist/utils/util'
 import * as libActions from '@nordcraft/std-lib/dist/actions'
 import * as libFormulas from '@nordcraft/std-lib/dist/formulas'
-import fastDeepEqual from 'fast-deep-equal'
+import { deepEqual as isEqual } from 'fast-equals'
 import { match } from 'path-to-regexp'
 import { isContextApiV2 } from './api/apiUtils'
 import { createLegacyAPI } from './api/createAPI'
@@ -61,7 +61,7 @@ export const initGlobalObject = (code?: {
     const legacyFormulas: Record<string, FormulaHandler> = {}
     const argumentInputDataList: Record<string, ArgumentInputDataFunction> = {}
     const toddle: Toddle<LocationSignal, never> = {
-      isEqual: fastDeepEqual,
+      isEqual,
       errors: [],
       project: window.__toddle.project,
       branch: window.__toddle.branch,

--- a/packages/runtime/src/signal/signal.ts
+++ b/packages/runtime/src/signal/signal.ts
@@ -1,4 +1,42 @@
-import fastDeepEqual from 'fast-deep-equal'
+import { createCustomEqual } from 'fast-equals'
+
+/**
+ * The APIv2 seems to save Header and FormData prototypes to the dataSignal, which is not supported by the default deepEqual implementation.
+ * The better solution would be to save these class instances as plain objects before they go into the signal.
+ * A refactor to APIv2 will allow us to use the default deepEqual implementation for everything.
+ */
+export const customIsEqual = createCustomEqual({
+  circular: false,
+  createCustomConfig: () => {
+    const customAreObjectsEqual = (a: unknown, b: unknown) => {
+      // If prototype of header, then compare via reference equality
+      if (a instanceof Headers && b instanceof Headers) {
+        return (
+          JSON.stringify([...a.entries()]) === JSON.stringify([...b.entries()])
+        )
+      }
+
+      if (a instanceof FormData && b instanceof FormData) {
+        return (
+          JSON.stringify([...a.entries()]) === JSON.stringify([...b.entries()])
+        )
+      }
+
+      console.warn(
+        'Unsupported custom type comparison, falling back to reference equality',
+        {
+          a,
+          b,
+        },
+      )
+      return a === b
+    }
+
+    return {
+      getUnsupportedCustomComparator: () => customAreObjectsEqual,
+    }
+  },
+})
 
 export class Signal<T> {
   value: T
@@ -24,7 +62,7 @@ export class Signal<T> {
       return
     }
 
-    if (fastDeepEqual(value, this.value) === false) {
+    if (customIsEqual(value, this.value) === false) {
       this.value = value
       for (const subscriber of this.subscribers) {
         subscriber.notify(this.value)
@@ -83,5 +121,5 @@ export function signal<T>(value: T) {
 
 if (typeof window !== 'undefined') {
   ;(window as any).signal = signal
-  ;(window as any).deepEqual = fastDeepEqual
+  ;(window as any).deepEqual = customIsEqual
 }

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -14,6 +14,7 @@
     "@nordcraft/core": "workspace:*",
     "jsondiffpatch": "0.7.3",
     "postcss": "8.5.8",
+    "fast-equals": "6.0.2",
     "zod": "4.2.1"
   },
   "scripts": {

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -14,8 +14,7 @@
     "@nordcraft/core": "workspace:*",
     "jsondiffpatch": "0.7.3",
     "postcss": "8.5.8",
-    "zod": "4.2.1",
-    "fast-deep-equal": "3.1.3"
+    "zod": "4.2.1"
   },
   "scripts": {
     "build": "tsgo",

--- a/packages/search/src/rules/search/fieldSearchRule.ts
+++ b/packages/search/src/rules/search/fieldSearchRule.ts
@@ -1,4 +1,4 @@
-import equal from 'fast-deep-equal'
+import { deepEqual as isEqual } from 'fast-equals'
 import type { SearchRule } from '../../types'
 import { parseSearchQuery } from '../../util/parseSearchQuery'
 
@@ -44,7 +44,10 @@ function checkStringMatch(
       try {
         // JSON parse only used for structural equality — not reproduced as output
         const parsed = JSON.parse(targetValue)
-        if (equal(stringVal, parsed) || equal(JSON.parse(stringVal), parsed)) {
+        if (
+          isEqual(stringVal, parsed) ||
+          isEqual(JSON.parse(stringVal), parsed)
+        ) {
           return fullMatch(stringVal)
         }
       } catch {
@@ -136,7 +139,7 @@ function matchString(value: any, matcher: string, key?: string): MatchResult {
     if (isExact) {
       if (isJsonStructuralTarget(targetValue)) {
         try {
-          if (equal(valToCheck, JSON.parse(targetValue)))
+          if (isEqual(valToCheck, JSON.parse(targetValue)))
             return fullMatch(targetValue)
         } catch {
           // fall through
@@ -185,7 +188,7 @@ function isMatch(
     return (
       Array.isArray(value) &&
       value.length >= matcher.length &&
-      matcher.every((m, i) => equal(value[i], m))
+      matcher.every((m, i) => isEqual(value[i], m))
     )
   }
 
@@ -194,7 +197,7 @@ function isMatch(
       return false
     }
     for (const key in matcher) {
-      if (!equal(value[key], (matcher as any)[key])) {
+      if (!isEqual(value[key], (matcher as any)[key])) {
         return false
       }
     }

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@nordcraft/core": "workspace:*",
     "@nordcraft/std-lib": "workspace:*",
-    "fast-deep-equal": "3.1.3",
+    "fast-equals": "6.0.2",
     "cookie": "1.0.2",
     "xss": "1.0.15"
   }

--- a/packages/ssr/src/rendering/equals.ts
+++ b/packages/ssr/src/rendering/equals.ts
@@ -1,9 +1,9 @@
 import type { Toddle } from '@nordcraft/core/dist/types'
-import fastDeepEqual from 'fast-deep-equal'
+import { deepEqual as isEqual } from 'fast-equals'
 
 export const initIsEqual = () => {
   const toddle: Pick<Toddle<never, never>, 'isEqual'> = {
-    isEqual: fastDeepEqual,
+    isEqual,
   }
   ;(globalThis as any).toddle = toddle
 }


### PR DESCRIPTION
Waiting for performance-metrics before this is to be merged.

According to standard benchmarks this should give a 1.2x improvement to equality checks which is often responsible for up to 50% of time taken for state changes. So this should give an overall **1.1x** improvement to performance, but needs to be validated first.