### PR TITLE
Enable no-misused-spread eslint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -63,6 +63,7 @@ export default defineConfig([
       '@typescript-eslint/no-confusing-non-null-assertion': 'error',
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-floating-promises': 'error',
+      '@typescript-eslint/no-misused-spread': 'error',
       '@typescript-eslint/no-non-null-asserted-nullish-coalescing': 'error',
       '@typescript-eslint/no-non-null-asserted-optional-chain': 'error',
       '@typescript-eslint/no-unnecessary-condition': 'warn',

--- a/packages/runtime/src/editor/overlay.test.ts
+++ b/packages/runtime/src/editor/overlay.test.ts
@@ -84,6 +84,7 @@ describe('getRectData()', () => {
     window.getComputedStyle = (el) => {
       if (el === parent) {
         return {
+          // eslint-disable-next-line @typescript-eslint/no-misused-spread
           ...originalGetComputedStyle(el),
           transform: 'matrix(0.866025, 0.5, -0.5, 0.866025, 0, 0)', // cos(30) = 0.866025, sin(30) = 0.5
           rotate: 'none',


### PR DESCRIPTION
See https://typescript-eslint.io/rules/no-misused-spread/ for details.